### PR TITLE
[FIX] APPROVALS: Postgres crash (bigint = character varying) in approval list-view queryset filter

### DIFF
--- a/horilla/contrib/process/approvals/signals.py
+++ b/horilla/contrib/process/approvals/signals.py
@@ -121,7 +121,15 @@ def _patch_horilla_list_view():
                 status__in=["pending", "rejected"],
                 is_active=True,
             ).values_list("object_id", flat=True)
-            return queryset.exclude(pk__in=pending_object_ids)
+            # ApprovalInstance.object_id is a CharField (GenericForeignKey id).
+            # Coerce to int before comparing against the integer PK: on PostgreSQL
+            # `pk IN (<varchar>)` raises "operator does not exist: bigint = character
+            # varying" (SQLite coerces silently), which broke every HorillaListView
+            # on Postgres deployments even with no approval rules configured.
+            pending_pks = [int(oid) for oid in pending_object_ids if str(oid).isdigit()]
+            if not pending_pks:
+                return queryset
+            return queryset.exclude(pk__in=pending_pks)
         except Exception:
             return queryset
 


### PR DESCRIPTION
## Summary
Fixes a `ProgrammingError: operator does not exist: bigint = character varying` that crashes **every list and detail page on PostgreSQL deployments** (including the default Docker setup) — even when no approval rules are configured. Reported by a user deploying via Docker.

## Symptom
```
ProgrammingError at /crm/leads/leads-list/   (also leads-detail, and every other module list)
operator does not exist: bigint = character varying
LINE 1: ... FROM "leads_lead" WHERE (NOT ("leads_lead"."id" IN (SELECT ...
HINT: No operator matches the given name and argument types. You might need to add explicit type casts.
```

## Root cause
`horilla/contrib/process/approvals/signals.py` → `_patch_horilla_list_view()` monkey-patches `HorillaListView.get_queryset` for every non-`approvals` model to hide records pending approval:

```python
pending_object_ids = ApprovalInstance.objects.filter(...).values_list("object_id", flat=True)
return queryset.exclude(pk__in=pending_object_ids)
```

`ApprovalInstance.object_id` is a `CharField` (GenericForeignKey id), so the generated SQL compares the integer PK (`bigint`) against a `varchar` subquery. **PostgreSQL rejects `bigint = character varying`; SQLite coerces it silently** — which is why it passes on the SQLite dev DB but breaks on Postgres.

Because the patch is applied unconditionally and PostgreSQL type-checks the `IN` comparison at plan time, it fails **even with zero `ApprovalInstance` rows**, breaking a fresh install immediately. The queryset is lazy, so the surrounding `try/except` (which only wraps queryset *construction*) never catches the error raised at *execution* time.

## Fix
Coerce the GenericFK `object_id` values to `int` in Python before the `exclude`, skip non-numeric ids, and short-circuit when nothing is pending — so the SQL becomes `pk NOT IN (<ints>)`, valid on both PostgreSQL and SQLite.

## Impact / scope
- Affects every `HorillaListView` (leads, accounts, contacts, opportunities, campaigns, …) and detail pages on PostgreSQL.
- One-file change, no migration, no behavioral change on SQLite.

## Testing
- `python -m py_compile` ✓; black-clean (88 cols).
- Suggested follow-up: a regression test on a PostgreSQL test DB (the bug is invisible under SQLite).
