### PR TITLE
fix(i18n): RTL role hierarchy lines and fa compilemessages errors

### DIFF
--- a/horilla/contrib/automations/locale/fa/LC_MESSAGES/django.po
+++ b/horilla/contrib/automations/locale/fa/LC_MESSAGES/django.po
@@ -379,6 +379,3 @@ msgstr "قالب"
 
 msgid "Condition"
 msgstr "شرط"
-
-msgid "Automate mail and notifications based on events in your workflow."
-msgstr "ارسال خودکار ایمیل و اعلان‌ها بر اساس رویدادهای گردش کار شما."

--- a/horilla/contrib/calendar/locale/fa/LC_MESSAGES/django.po
+++ b/horilla/contrib/calendar/locale/fa/LC_MESSAGES/django.po
@@ -696,6 +696,3 @@ msgstr "با موفقیت به عنوان تکمیل شده علامت‌گذا�
 
 msgid "Mark Unavailability"
 msgstr "علامت‌گذاری عدم دسترسی"
-
-msgid "Sync your calendar and meetings with your Google account."
-msgstr "تقویم و جلسات خود را با حساب Google خود همگام‌سازی کنید."

--- a/horilla/contrib/dashboard/locale/fa/LC_MESSAGES/django.po
+++ b/horilla/contrib/dashboard/locale/fa/LC_MESSAGES/django.po
@@ -656,15 +656,3 @@ msgstr "ترتیب چیدمان ذخیره شد."
 
 msgid "Layout reset to default."
 msgstr "چیدمان به پیش‌فرض بازنشانی شد."
-
-#, python-format
-msgid "Total %(name)s"
-msgstr "کل %(name)s"
-
-#, python-format
-msgid "%(name)s (%(index)d)"
-msgstr "%(name)s (%(index)d)"
-
-#, python-format
-msgid "No %(name)s found."
-msgstr "هیچ %(name)s یافت نشد."

--- a/horilla/contrib/duplicates/locale/fa/LC_MESSAGES/django.po
+++ b/horilla/contrib/duplicates/locale/fa/LC_MESSAGES/django.po
@@ -373,9 +373,3 @@ msgstr "ادغام انتخاب شده‌ها"
 
 msgid "Record"
 msgstr "رکورد"
-
-msgid "Define which fields are compared to detect matching records."
-msgstr "تعیین کنید که کدام فیلدها برای تشخیص رکوردهای منطبق مقایسه شوند."
-
-msgid "Set how duplicate records are handled once matched."
-msgstr "تعیین کنید که پس از تشخیص، رکوردهای تکراری چگونه مدیریت شوند."

--- a/horilla/contrib/mail/locale/fa/LC_MESSAGES/django.po
+++ b/horilla/contrib/mail/locale/fa/LC_MESSAGES/django.po
@@ -788,15 +788,3 @@ msgstr "تجدید توکن ناموفق بود: {error}. لطفاً دوبار�
 #, python-brace-format
 msgid "Token refresh failed: {error}"
 msgstr "تجدید توکن ناموفق بود: {error}"
-
-msgid "Configure the SMTP server used to send outgoing emails."
-msgstr "پیکربندی سرور SMTP مورد استفاده برای ارسال ایمیل‌های خروجی."
-
-msgid "Configure the IMAP server used to receive incoming emails."
-msgstr "پیکربندی سرور IMAP مورد استفاده برای دریافت ایمیل‌های ورودی."
-
-msgid "Create reusable email templates for common messages."
-msgstr "ایجاد قالب‌های ایمیل قابل استفاده مجدد برای پیام‌های رایج."
-
-msgid "Mail History"
-msgstr "تاریخچه ایمیل"

--- a/horilla/contrib/meeting/locale/fa/LC_MESSAGES/django.po
+++ b/horilla/contrib/meeting/locale/fa/LC_MESSAGES/django.po
@@ -546,6 +546,3 @@ msgstr "لطفاً ابتدا شناسه کلاینت، راز و شناسه م�
 
 msgid "Teams account connected successfully."
 msgstr "حساب تیمز با موفقیت متصل شد."
-
-msgid "Connect and manage the meeting providers available to your organization."
-msgstr "ارائه‌دهندگان جلسه در دسترس سازمان خود را متصل و مدیریت کنید."

--- a/horilla_crm/forecast/locale/fa/LC_MESSAGES/django.po
+++ b/horilla_crm/forecast/locale/fa/LC_MESSAGES/django.po
@@ -448,6 +448,3 @@ msgstr ""
 
 msgid "Filter Opportunities"
 msgstr "فیلتر فرصت‌ها"
-
-msgid "Define the categories used to group your sales forecasts."
-msgstr "دسته‌بندی‌های مورد استفاده برای گروه‌بندی پیش‌بینی‌های فروش خود را تعریف کنید."

--- a/horilla_crm/scoring_rules/locale/fa/LC_MESSAGES/django.po
+++ b/horilla_crm/scoring_rules/locale/fa/LC_MESSAGES/django.po
@@ -119,6 +119,3 @@ msgstr "داده‌های درخواستی وجود ندارند."
 
 msgid "Create New Rule Criteria"
 msgstr "ایجاد معیار قانون جدید"
-
-msgid "Define rules that automatically score leads and opportunities."
-msgstr "قوانینی برای امتیازدهی خودکار سرنخ‌ها و فرصت‌ها تعریف کنید."

--- a/static/assets/css/rtl.css
+++ b/static/assets/css/rtl.css
@@ -389,3 +389,24 @@ html[dir="rtl"] .horilla-dashboard-sortable.is-edit-sortable > [data-id] {
   direction: rtl;
   unicode-bidi: isolate;
 }
+
+/*
+ * Roles hierarchy — org chart connectors use physical left/right borders.
+ * Keep the tree layout LTR so connecting lines render correctly; restore RTL
+ * text direction inside role/company cards only.
+ */
+[dir="rtl"] .genealogy-tree {
+  direction: ltr;
+  unicode-bidi: isolate;
+}
+
+[dir="rtl"] .genealogy-tree .member-header,
+[dir="rtl"] .genealogy-tree .member-footer,
+[dir="rtl"] .genealogy-tree .member-footer div.name,
+[dir="rtl"] .genealogy-tree .member-footer div.downline {
+  direction: rtl;
+}
+
+[dir="rtl"] .genealogy-tree .member-footer div.downline {
+  justify-content: center;
+}


### PR DESCRIPTION
## Summary

Addresses review feedback on PR #20 (separate from the Jalali extension):

- **Roles View RTL** — Fix broken hierarchy/connecting lines in the Roles View when using Persian (`fa`). Org chart layout stays LTR for correct connectors; card text remains RTL.
- **compilemessages** — Remove duplicate `msgid` entries in `locale/fa/LC_MESSAGES/django.po` that caused `msgfmt` failures in Mail, Calendar, Dashboard, Forecast, Meeting, Scoring Rules, Duplicates, and Automations.

## Changes

- `static/assets/css/rtl.css` — RTL overrides for `.genealogy-tree` role hierarchy
- 8 × `locale/fa/LC_MESSAGES/django.po` — remove duplicate message definitions

## Test plan

- [ ] Switch UI language to Persian (`fa`)
- [ ] Settings → Roles View (hierarchy/kanban): connecting lines render correctly in RTL
- [ ] Run `python manage.py compilemessages -l fa` — completes with no errors
- [ ] Smoke-check Mail, Calendar, Dashboard, Meeting, Forecast, Duplicates, Scoring Rules in Persian UI

## Note

After this PR and PR #20 (`horilla_jalali`) are merged, I will go fix the mistranslations and find the untranslated sentences in the UI. After that, we can say that the Persian Horilla CRM is officially ready.