### PR TITLE
fix(i18n): interpolate Persian copy and unshadow gettext in delete

### DIFF
--- a/calls/extensions.py
+++ b/calls/extensions.py
@@ -3,6 +3,7 @@
 from horilla.contrib.activity.views.list_view.tab_views import _CALL_TAB_ACTIONS
 from horilla.contrib.core.models import HorillaCoreModel
 from horilla.urls import reverse_lazy
+from horilla.utils.translation import gettext_lazy as _
 
 _CALL_NOW_ACTION = {
     "action": "Call Now",
@@ -21,6 +22,10 @@ class ActivityCallExtension(HorillaCoreModel):
     """Injects get_call_now_url onto the Activity model."""
 
     _inherit = "activity.Activity"
+
+    class Meta:
+        verbose_name = _("Activity Call Extension")
+        verbose_name_plural = _("Activity Call Extensions")
 
     def get_call_now_url(self):
         """Return the click-to-call URL pre-filled with this activity's linked object."""

--- a/calls/locale/fa/LC_MESSAGES/django.po
+++ b/calls/locale/fa/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2026-08-18 14:05+0000\n"
-"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"PO-Revision-Date: 2026-08-24 12:00+0330\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "Language: fa\n"
@@ -18,7 +18,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
 msgid "Calls Integration"
-msgstr ""
+msgstr "یکپارچه‌سازی تماس"
 
 msgid ""
 "Telephony integration for click-to-call from CRM records, multi-provider "
@@ -50,109 +50,109 @@ msgid ""
 msgstr ""
 
 msgid "Account SID"
-msgstr ""
+msgstr "شناسه SID حساب"
 
 msgid "API Key"
-msgstr ""
+msgstr "کلید API"
 
 msgid "Auth Token / API Secret"
-msgstr ""
+msgstr "توکن احراز هویت / رمز API"
 
 msgid "API Base URL"
-msgstr ""
+msgstr "URL پایه API"
 
 msgid "Webhook Secret"
-msgstr ""
+msgstr "رمز وب‌هوک"
 
 msgid "Leave blank to keep existing"
-msgstr ""
+msgstr "برای حفظ مقدار موجود خالی بگذارید"
 
 msgid "Roles"
-msgstr ""
+msgstr "نقش‌ها"
 
 msgid "Select roles"
-msgstr ""
+msgstr "انتخاب نقش‌ها"
 
 msgid "Users"
-msgstr ""
+msgstr "کاربران"
 
 msgid "Select users"
-msgstr ""
+msgstr "انتخاب کاربران"
 
 msgid "Call Integration"
-msgstr ""
+msgstr "یکپارچه‌سازی تماس"
 
 msgid "Calls"
-msgstr ""
+msgstr "تماس‌ها"
 
 msgid "All Users"
-msgstr ""
+msgstr "همه کاربران"
 
 msgid "Specific Roles"
-msgstr ""
+msgstr "نقش‌های مشخص"
 
 msgid "Specific Users"
-msgstr ""
+msgstr "کاربران مشخص"
 
 msgid "Enabled"
-msgstr ""
+msgstr "فعال"
 
 msgid "Access Type"
-msgstr ""
+msgstr "نوع دسترسی"
 
 msgid "Who can initiate calls."
-msgstr ""
+msgstr "چه کسانی می‌توانند تماس برقرار کنند."
 
 msgid "Allowed Roles"
-msgstr ""
+msgstr "نقش‌های مجاز"
 
 msgid "Allowed Users"
-msgstr ""
+msgstr "کاربران مجاز"
 
 msgid "Call Integration Setting"
-msgstr ""
+msgstr "تنظیمات یکپارچه‌سازی تماس"
 
 msgid "Call Integration Settings"
-msgstr ""
+msgstr "تنظیمات یکپارچه‌سازی تماس"
 
 msgid "Twilio"
-msgstr ""
+msgstr "Twilio"
 
 msgid "SignalWire (Beta)"
-msgstr ""
+msgstr "SignalWire (بتا)"
 
 msgid "Telnyx (Beta)"
-msgstr ""
+msgstr "Telnyx (بتا)"
 
 msgid "Sinch (Beta)"
-msgstr ""
+msgstr "Sinch (بتا)"
 
 msgid "Exotel (Beta)"
-msgstr ""
+msgstr "Exotel (بتا)"
 
 msgid "Mock (Testing)"
-msgstr ""
+msgstr "Mock (آزمایشی)"
 
 msgid "Active"
-msgstr ""
+msgstr "فعال"
 
 msgid "Inactive"
-msgstr ""
+msgstr "غیرفعال"
 
 msgid "Testing"
-msgstr ""
+msgstr "در حال آزمایش"
 
 msgid "Name"
-msgstr ""
+msgstr "نام"
 
 msgid "Provider"
-msgstr ""
+msgstr "ارائه‌دهنده"
 
 msgid "Status"
-msgstr ""
+msgstr "وضعیت"
 
 msgid "Account SID / App ID"
-msgstr ""
+msgstr "شناسه SID حساب / شناسه برنامه"
 
 msgid ""
 "Twilio AccountSID, Plivo Auth ID, Ozonetel username, or equivalent "
@@ -160,19 +160,19 @@ msgid ""
 msgstr ""
 
 msgid "API Secret / Auth Token"
-msgstr ""
+msgstr "رمز API / توکن احراز هویت"
 
 msgid "Optional override for Ozonetel or custom API endpoints."
 msgstr ""
 
 msgid "Default Caller ID"
-msgstr ""
+msgstr "شناسه تماس‌گیرنده پیش‌فرض"
 
 msgid "Default outbound phone number or SIP caller ID."
 msgstr ""
 
 msgid "Enable Call Recording"
-msgstr ""
+msgstr "فعال‌سازی ضبط تماس"
 
 msgid ""
 "Record calls via this provider. Requires recording support on the provider "
@@ -183,106 +183,106 @@ msgid "Used to validate incoming webhook signatures."
 msgstr ""
 
 msgid "Extra Configuration"
-msgstr ""
+msgstr "پیکربندی اضافی"
 
 msgid "Call Provider"
-msgstr ""
+msgstr "ارائه‌دهنده تماس"
 
 msgid "Call Providers"
-msgstr ""
+msgstr "ارائه‌دهندگان تماس"
 
 msgid "User"
-msgstr ""
+msgstr "کاربر"
 
 msgid "Extension / SIP Extension"
-msgstr ""
+msgstr "داخلی / داخلی SIP"
 
 msgid "Agent / Caller ID"
-msgstr ""
+msgstr "نماینده / شناسه تماس‌گیرنده"
 
 msgid "Provider's internal agent or caller identifier."
 msgstr ""
 
 msgid "Agent Mapping"
-msgstr ""
+msgstr "نگاشت نماینده"
 
 msgid "Agent Mappings"
-msgstr ""
+msgstr "نگاشت‌های نماینده"
 
 msgid "Inbound"
-msgstr ""
+msgstr "ورودی"
 
 msgid "Outbound"
-msgstr ""
+msgstr "خروجی"
 
 msgid "Initiated"
-msgstr ""
+msgstr "آغاز شده"
 
 msgid "Ringing"
-msgstr ""
+msgstr "در حال زنگ"
 
 msgid "In Progress"
-msgstr ""
+msgstr "در حال انجام"
 
 msgid "Completed"
-msgstr ""
+msgstr "تکمیل شده"
 
 msgid "No Answer"
-msgstr ""
+msgstr "بدون پاسخ"
 
 msgid "Busy"
-msgstr ""
+msgstr "مشغول"
 
 msgid "Failed"
-msgstr ""
+msgstr "ناموفق"
 
 msgid "Cancelled"
-msgstr ""
+msgstr "لغو شده"
 
 msgid "Agent"
-msgstr ""
+msgstr "نماینده"
 
 msgid "Direction"
-msgstr ""
+msgstr "جهت"
 
 msgid "From Number"
-msgstr ""
+msgstr "از شماره"
 
 msgid "To Number"
-msgstr ""
+msgstr "به شماره"
 
 msgid "Duration (seconds)"
-msgstr ""
+msgstr "مدت زمان (ثانیه)"
 
 msgid "Started At"
-msgstr ""
+msgstr "شروع در"
 
 msgid "Ended At"
-msgstr ""
+msgstr "پایان در"
 
 msgid "Provider Call ID"
-msgstr ""
+msgstr "شناسه تماس ارائه‌دهنده"
 
 msgid "Twilio CallSID, Plivo RequestUUID, Vonage UUID, Ozonetel UCID, etc."
 msgstr ""
 
 msgid "Recording URL"
-msgstr ""
+msgstr "URL ضبط"
 
 msgid "Related Model"
-msgstr ""
+msgstr "مدل مرتبط"
 
 msgid "'lead' or 'contact'"
 msgstr ""
 
 msgid "Related Object ID"
-msgstr ""
+msgstr "شناسه شیء مرتبط"
 
 msgid "Call Log"
-msgstr ""
+msgstr "گزارش تماس"
 
 msgid "Call Logs"
-msgstr ""
+msgstr "گزارش‌های تماس"
 
 msgid "How to configure your Caller ID"
 msgstr ""
@@ -291,10 +291,10 @@ msgid "Log in to Twilio Console"
 msgstr ""
 
 msgid "Visit"
-msgstr ""
+msgstr "بازدید"
 
 msgid "and sign in."
-msgstr ""
+msgstr "و وارد شوید."
 
 msgid "Go to Phone Numbers"
 msgstr ""
@@ -486,7 +486,7 @@ msgid "Enter any phone number in E.164 format (e.g. +919XXXXXXXXX)."
 msgstr ""
 
 msgid "Caller ID"
-msgstr ""
+msgstr "شناسه تماس‌گیرنده"
 
 msgid "(optional)"
 msgstr ""
@@ -499,22 +499,22 @@ msgid ""
 msgstr ""
 
 msgid "Save"
-msgstr ""
+msgstr "ذخیره"
 
 msgid "Close"
-msgstr ""
+msgstr "بستن"
 
 msgid "Call Log Detail"
-msgstr ""
+msgstr "جزئیات گزارش تماس"
 
 msgid "From"
-msgstr ""
+msgstr "از"
 
 msgid "To"
-msgstr ""
+msgstr "تا"
 
 msgid "Duration"
-msgstr ""
+msgstr "مدت زمان"
 
 msgid "Started"
 msgstr ""
@@ -535,16 +535,16 @@ msgid "Hang Up"
 msgstr ""
 
 msgid "Cancel Call"
-msgstr ""
+msgstr "لغو تماس"
 
 msgid "Call Accounts"
-msgstr ""
+msgstr "حساب‌های تماس"
 
 msgid "Manage the calling accounts connected to your profile."
 msgstr ""
 
 msgid "Call Integration Disabled"
-msgstr ""
+msgstr "یکپارچه‌سازی تماس غیرفعال است"
 
 msgid ""
 "Call integration is not currently enabled for your account. Please contact "
@@ -552,7 +552,7 @@ msgid ""
 msgstr ""
 
 msgid "No Providers Configured"
-msgstr ""
+msgstr "ارائه‌دهنده‌ای پیکربندی نشده است"
 
 msgid ""
 "Ask your administrator to add a provider under Settings → Integrations → "
@@ -566,10 +566,10 @@ msgid "Edit Configuration"
 msgstr ""
 
 msgid "Call"
-msgstr ""
+msgstr "تماس"
 
 msgid "Make a Call"
-msgstr ""
+msgstr "برقراری تماس"
 
 msgid "Phone Number"
 msgstr ""
@@ -581,20 +581,20 @@ msgid "No phone number found on this record. Please enter one."
 msgstr ""
 
 msgid "Select provider..."
-msgstr ""
+msgstr "انتخاب ارائه‌دهنده..."
 
 msgid "Cancel"
-msgstr ""
+msgstr "لغو"
 
 msgid "Call Now"
-msgstr ""
+msgstr "تماس فوری"
 
 msgid "Connect a calling provider to make and log calls from Horilla."
 msgstr ""
 "یک ارائه‌دهنده تماس را برای برقراری و ثبت تماس‌ها از هورایلا متصل کنید."
 
 msgid "Call Settings"
-msgstr ""
+msgstr "تنظیمات تماس"
 
 msgid ""
 "Enable call integration to allow users to make and receive calls directly "
@@ -604,7 +604,7 @@ msgstr ""
 " برقرار کرده و تماس دریافت کنند."
 
 msgid "Enable Call Integration"
-msgstr ""
+msgstr "فعال‌سازی یکپارچه‌سازی تماس"
 
 msgid "Enable Call Integration?"
 msgstr ""
@@ -632,7 +632,7 @@ msgid "Choose who can initiate calls."
 msgstr ""
 
 msgid "Set access to All Users?"
-msgstr ""
+msgstr "دسترسی را به همه کاربران تنظیم کنیم؟"
 
 msgid "Every user in the company will be able to initiate calls."
 msgstr ""
@@ -656,7 +656,7 @@ msgid "role"
 msgstr ""
 
 msgid "roles"
-msgstr ""
+msgstr "نقش‌ها"
 
 msgid "Switch to Specific Users?"
 msgstr ""
@@ -674,13 +674,13 @@ msgid "user"
 msgstr ""
 
 msgid "users"
-msgstr ""
+msgstr "کاربران"
 
 msgid "Setup guides"
 msgstr ""
 
 msgid "Add"
-msgstr ""
+msgstr "افزودن"
 
 msgid "Please enter a phone number to call."
 msgstr ""
@@ -695,40 +695,40 @@ msgid "Ringing…"
 msgstr ""
 
 msgid "Call Ended"
-msgstr ""
+msgstr "تماس پایان یافت"
 
 msgid "Call Declined"
-msgstr ""
+msgstr "تماس رد شد"
 
 msgid "Call Failed"
-msgstr ""
+msgstr "تماس ناموفق بود"
 
 msgid "Call Cancelled"
-msgstr ""
+msgstr "تماس لغو شد"
 
 msgid "Date & Time"
-msgstr ""
+msgstr "تاریخ و زمان"
 
 msgid "Access Control"
-msgstr ""
+msgstr "کنترل دسترسی"
 
 msgid "Providers"
-msgstr ""
+msgstr "ارائه‌دهندگان"
 
 msgid "Select Roles"
-msgstr ""
+msgstr "انتخاب نقش‌ها"
 
 msgid "Select Users"
-msgstr ""
+msgstr "انتخاب کاربران"
 
 msgid "Roles with Call Access"
-msgstr ""
+msgstr "نقش‌های دارای دسترسی تماس"
 
 msgid "No roles selected yet."
 msgstr ""
 
 msgid "Users with Call Access"
-msgstr ""
+msgstr "کاربران دارای دسترسی تماس"
 
 msgid "No users selected yet."
 msgstr ""
@@ -744,3 +744,12 @@ msgstr ""
 
 msgid "Provider status updated successfully."
 msgstr ""
+
+msgid "Activity Call Extension"
+msgstr "افزونه تماس فعالیت"
+
+msgid "Activity Call Extensions"
+msgstr "افزونه‌های تماس فعالیت"
+
+msgid "activity call extension"
+msgstr "افزونه تماس فعالیت"

--- a/horilla/contrib/core/templates/permissions/assign_perm_form.html
+++ b/horilla/contrib/core/templates/permissions/assign_perm_form.html
@@ -116,7 +116,7 @@
                                             hx-swap="innerHTML"
                                             onclick="openModal()"
                                         >
-                                            {{ model.verbose_name }}
+                                            {% trans model.verbose_name %}
                                         </button>
                                     {% else %}
                                         <div
@@ -124,7 +124,7 @@
                                             title="{% trans 'Field permissions not available for this model' %}"
                                             aria-label="{% trans 'Field permissions not available for this model' %}"
                                         >
-                                            {{ model.verbose_name }}
+                                            {% trans model.verbose_name %}
                                         </div>
                                     {% endif %}
                                 </div>
@@ -140,7 +140,7 @@
                                                     checked
                                                 {% endif %}
                                             >
-                                            {{ perm.label }}
+                                            {% trans perm.label %}
                                         </label>
                                     {% endfor %}
                                 </div>

--- a/horilla/contrib/core/templates/permissions/search_permission/assign_models_list.html
+++ b/horilla/contrib/core/templates/permissions/search_permission/assign_models_list.html
@@ -27,7 +27,7 @@
                             hx-swap="innerHTML"
                             onclick="openModal()"
                         >
-                            {{ model.verbose_name }}
+                            {% trans model.verbose_name %}
                         </button>
                     {% else %}
                         <div
@@ -35,7 +35,7 @@
                             title="{% trans 'Field permissions not available for this model' %}"
                             aria-label="{% trans 'Field permissions not available for this model' %}"
                         >
-                            {{ model.verbose_name }}
+                            {% trans model.verbose_name %}
                         </div>
                     {% endif %}
                 </div>
@@ -52,7 +52,7 @@
                                 checked
                             {% endif %}
                         >
-                        {{ perm.label }}
+                        {% trans perm.label %}
                     </label>
                 {% endfor %}
             </div>

--- a/horilla/contrib/core/templates/permissions/search_permission/role_models_list.html
+++ b/horilla/contrib/core/templates/permissions/search_permission/role_models_list.html
@@ -24,7 +24,7 @@
                         hx-swap="innerHTML"
                         onclick="openModal()"
                     >
-                        {{ model.verbose_name }}
+                        {% trans model.verbose_name %}
                     </button>
                 {% else %}
                     <div
@@ -32,7 +32,7 @@
                         title="{% trans 'Field permissions not available for this model' %}"
                         aria-label="{% trans 'Field permissions not available for this model' %}"
                     >
-                        {{ model.verbose_name }}
+                        {% trans model.verbose_name %}
                     </div>
                 {% endif %}
             </div>
@@ -54,7 +54,7 @@
                             hx-on::after-request="$('#reloadMessagesButton').click();"
                             hx-swap="innerHTML"
                         >
-                        {{ perm.label }}
+                        {% trans perm.label %}
                     </label>
                 {% endfor %}
             </div>

--- a/horilla/contrib/core/templates/permissions/search_permission/user_models_list.html
+++ b/horilla/contrib/core/templates/permissions/search_permission/user_models_list.html
@@ -24,7 +24,7 @@
                         hx-swap="innerHTML"
                         onclick="openModal()"
                     >
-                        {{ model.verbose_name }}
+                        {% trans model.verbose_name %}
                     </button>
                 {% else %}
                     <div
@@ -32,7 +32,7 @@
                         title="{% trans 'Field permissions not available for this model' %}"
                         aria-label="{% trans 'Field permissions not available for this model' %}"
                     >
-                        {{ model.verbose_name }}
+                        {% trans model.verbose_name %}
                     </div>
                 {% endif %}
             </div>
@@ -55,7 +55,7 @@
                             hx-target="#messages-container"
                             hx-swap="innerHTML"
                         >
-                        {{ perm.label }}
+                        {% trans perm.label %}
                     </label>
                 {% endfor %}
             </div>

--- a/horilla/contrib/core/views/groups_and_permissions/permission_utils.py
+++ b/horilla/contrib/core/views/groups_and_permissions/permission_utils.py
@@ -72,7 +72,10 @@ class PermissionUtils:
         for perm in permissions:
             if perm.codename in standard_codenames:
                 continue
-            label = perm.name if perm.name else perm.codename.replace("_", " ").title()
+            if perm.name:
+                label = _(perm.name)
+            else:
+                label = _(perm.codename.replace("_", " ").title())
 
             simplified_permissions.append(
                 {
@@ -135,8 +138,8 @@ class PermissionUtils:
                 model_data = {
                     "app_label": app_label,
                     "model_name": model_name,
-                    "verbose_name": model._meta.verbose_name.title(),
-                    "verbose_name_plural": model._meta.verbose_name_plural.title(),
+                    "verbose_name": model._meta.verbose_name,
+                    "verbose_name_plural": model._meta.verbose_name_plural,
                     "permissions": permissions,
                     "is_managed": model._meta.managed,
                     "has_export": has_export,

--- a/horilla/contrib/generics/locale/fa/LC_MESSAGES/django.po
+++ b/horilla/contrib/generics/locale/fa/LC_MESSAGES/django.po
@@ -177,7 +177,11 @@ msgstr ""
 "                        "
 
 msgid "Nothing to show yet. Please add your"
-msgstr "هنوز چیزی برای نمایش وجود ندارد. لطفاً"
+msgstr "هنوز چیزی برای نمایش وجود ندارد. لطفاً مورد خود را اضافه کنید."
+
+#, python-format
+msgid "Nothing to show yet. Please add your %(model)s."
+msgstr "هنوز چیزی برای نمایش وجود ندارد. لطفاً %(model)s را اضافه کنید."
 
 #| msgid "Are you sure you want to delete the"
 msgid "Are you sure you want to delete this saved list?"
@@ -459,7 +463,7 @@ msgstr ""
 "                    "
 
 msgid " Nothing to show yet. Please add your"
-msgstr "هنوز چیزی برای نمایش وجود ندارد. لطفاً"
+msgstr "هنوز چیزی برای نمایش وجود ندارد. لطفاً مورد خود را اضافه کنید."
 
 msgid "All Items"
 msgstr "همه موارد"
@@ -1264,3 +1268,91 @@ msgstr "لطفاً یک گزینه معتبر برای فیلد عملگر ان�
 
 msgid "Please select a valid choice for the field."
 msgstr "لطفاً یک گزینه معتبر برای فیلد انتخاب کنید."
+
+#, python-format
+msgid "Successfully deleted the %(model)s and all its related records."
+msgstr "%(model)s و همه رکوردهای مرتبط آن با موفقیت حذف شد."
+
+#, python-format
+msgid "Successfully reassigned %(count)d records and deleted the %(model)s."
+msgstr "%(count)d رکورد با موفقیت تخصیص مجدد شد و %(model)s حذف شد."
+
+#, python-format
+msgid "Reassigned %(count)d records and deleted %(record)s"
+msgstr "%(count)d رکورد تخصیص مجدد شد و %(record)s حذف شد"
+
+#, python-format
+msgid "Processed dependency records and deleted %(record)s"
+msgstr "رکوردهای وابسته پردازش شد و %(record)s حذف شد"
+
+#, python-format
+msgid "Reassigned %(count)d records"
+msgstr "%(count)d رکورد تخصیص مجدد شد"
+
+msgid "Processed dependency records"
+msgstr "رکوردهای وابسته پردازش شد"
+
+#, python-format
+msgid "Successfully deleted %(record)s."
+msgstr "%(record)s با موفقیت حذف شد."
+
+msgid "Successfully set record to null."
+msgstr "رکورد با موفقیت خالی شد."
+
+msgid "The record was deleted successfully."
+msgstr "رکورد با موفقیت حذف شد."
+
+#, python-format
+msgid "You don't have permission to delete this %(model)s."
+msgstr "شما مجوز حذف این %(model)s را ندارید."
+
+#, python-format
+msgid "You don't have permission to delete %(model)s."
+msgstr "شما مجوز حذف %(model)s را ندارید."
+
+msgid "Error in delete method"
+msgstr "خطا در روش حذف"
+
+#, python-format
+msgid "Error in delete method: %(error)s"
+msgstr "خطا در روش حذف: %(error)s"
+
+#, python-format
+msgid "Delete %(model)s with Dependencies"
+msgstr "حذف %(model)s با وابستگی‌ها"
+
+#, python-format
+msgid "The %(model)s \"%(obj)s\" has dependencies and cannot be deleted directly."
+msgstr "%(model)s «%(obj)s» دارای وابستگی است و نمی‌توان آن را مستقیماً حذف کرد."
+
+#, python-format
+msgid "Are you sure you want to delete the %(model)s \"%(obj)s\"?"
+msgstr "آیا مطمئن هستید که می‌خواهید %(model)s «%(obj)s» را حذف کنید؟"
+
+#, python-format
+msgid "Choose the deletion mode for %(model)s \"%(obj)s\"."
+msgstr "حالت حذف را برای %(model)s «%(obj)s» انتخاب کنید."
+
+#, python-format
+msgid "Are you sure you want to hard delete the selected %(model)s?"
+msgstr "آیا مطمئن هستید که می‌خواهید %(model)s انتخاب‌شده را به‌صورت دائمی حذف کنید؟"
+
+#, python-format
+msgid "Are you sure you want to soft delete the selected %(model)s?"
+msgstr "آیا مطمئن هستید که می‌خواهید %(model)s انتخاب‌شده را به‌صورت نرم حذف کنید؟"
+
+#, python-format
+msgid "Reassign all dependent %(model)s to a new target before deleting \"%(obj)s\"."
+msgstr "قبل از حذف «%(obj)s»، همه %(model)s وابسته را به یک هدف جدید تخصیص مجدد دهید."
+
+#, python-format
+msgid "Choose actions for each dependent %(model)s before deleting \"%(obj)s\"."
+msgstr "قبل از حذف «%(obj)s»، برای هر %(model)s وابسته یک اقدام انتخاب کنید."
+
+#, python-format
+msgid "Soft deleting this <strong>%(model)s</strong> will also soft delete all its related <strong>%(related)s</strong>."
+msgstr "حذف نرم این <strong>%(model)s</strong> همه <strong>%(related)s</strong> مرتبط را نیز به‌صورت نرم حذف می‌کند."
+
+#, python-format
+msgid "Permanently deleting this <strong>%(model)s</strong> will also permanently delete all its related <strong>%(related)s</strong>."
+msgstr "حذف دائمی این <strong>%(model)s</strong> همه <strong>%(related)s</strong> مرتبط را نیز به‌صورت دائمی حذف می‌کند."

--- a/horilla/contrib/generics/templates/card_view.html
+++ b/horilla/contrib/generics/templates/card_view.html
@@ -96,7 +96,7 @@
                     </p>
                 {% else %}
                     <p class="text-sm text-center pb-3">
-                        {% trans 'Nothing to show yet. Please add your' %} {{ model_verbose_name }}.
+                        {% empty_add_message model_verbose_name %}
                     </p>
                 {% endif %}
 

--- a/horilla/contrib/generics/templates/chart_view.html
+++ b/horilla/contrib/generics/templates/chart_view.html
@@ -292,7 +292,7 @@
                         </p>
                     {% else %}
                         <p class="text-sm text-center pb-3">
-                            {% trans ' Nothing to show yet. Please add your' %} {{ model_verbose_name }}.
+                            {% empty_add_message model_verbose_name %}
                         </p>
                     {% endif %}
                     {% if view_type|slice:":11" == "saved_list_" and saved_list_is_owner %}

--- a/horilla/contrib/generics/templates/group_by_view.html
+++ b/horilla/contrib/generics/templates/group_by_view.html
@@ -393,7 +393,7 @@
                 {% elif has_active_filters %}
                     {% trans 'No matching records found. Try adjusting your search or filters.' %}
                 {% else %}
-                    {% trans "Nothing to show yet. Please add your" %} {{ model_verbose_name }}.
+                    {% empty_add_message model_verbose_name %}
                 {% endif %}
             </p>
             {% if no_record_add_button.url and not has_active_filters %}

--- a/horilla/contrib/generics/templates/kanban_view.html
+++ b/horilla/contrib/generics/templates/kanban_view.html
@@ -74,7 +74,7 @@
             {% elif has_active_filters %}
                 {% trans 'No matching records found. Try adjusting your search or filters.' %}
             {% else %}
-                {% trans "Nothing to show yet. Please add your" %} {{ model_verbose_name }}.
+                {% empty_add_message model_verbose_name %}
             {% endif %}
         </p>
         {% if no_record_add_button.url and not has_active_filters %}

--- a/horilla/contrib/generics/templates/list_view.html
+++ b/horilla/contrib/generics/templates/list_view.html
@@ -497,7 +497,7 @@
                     </p>
                 {% else %}
                     <p class="text-sm text-center pb-3">
-                        {% trans 'Nothing to show yet. Please add your' %} {{ model_verbose_name }}.
+                        {% empty_add_message model_verbose_name %}
                     </p>
                 {% endif %}
                 {% if view_type|slice:":11" == "saved_list_" and saved_list_is_owner %}

--- a/horilla/contrib/generics/templates/partials/bulk_delete_form.html
+++ b/horilla/contrib/generics/templates/partials/bulk_delete_form.html
@@ -4,7 +4,7 @@
     </div>
     {% if not cannot_delete %}
         <p class="text-sm text-gray-600 mb-4">
-            {% trans 'Are you sure you want to hard delete the selected' %} {{ model_verbose_name }}?
+            {% blocktrans trimmed with model=model_verbose_name %}Are you sure you want to hard delete the selected {{ model }}?{% endblocktrans %}
         </p>
     {% endif %}
     <p class="text-sm text-gray-600 mb-2">

--- a/horilla/contrib/generics/templates/partials/single_delete/bulk_reassign_form.html
+++ b/horilla/contrib/generics/templates/partials/single_delete/bulk_reassign_form.html
@@ -6,9 +6,7 @@
         </button>
     </div>
     <p class="text-sm text-gray-600 mb-4">
-        {% trans 'Reassign all dependent' %}
-        {{ model_verbose_name }}
-        {% trans 'to a new target before deleting' %} "{{ object }}".
+        {% blocktrans trimmed with model=model_verbose_name obj=object %}Reassign all dependent {{ model }} to a new target before deleting "{{ obj }}".{% endblocktrans %}
     </p>
     <form
         hx-post="{{ search_url }}"

--- a/horilla/contrib/generics/templates/partials/single_delete/delete_all_confirm.html
+++ b/horilla/contrib/generics/templates/partials/single_delete/delete_all_confirm.html
@@ -7,12 +7,9 @@
     </div>
     <p class="text-sm text-gray-600 mb-4">
         {% if delete_mode == 'main_soft' %}
-            {% trans 'Soft deleting this' %} <strong>{{ model_verbose_name }}</strong>
-            {% trans 'will also soft delete all its related' %} <strong>{{ related_verbose_name_plural }}</strong>.
+            {% blocktrans trimmed with model=model_verbose_name related=related_verbose_name_plural %}Soft deleting this <strong>{{ model }}</strong> will also soft delete all its related <strong>{{ related }}</strong>.{% endblocktrans %}
         {% else %}
-            {% trans 'Permanently deleting this' %} <strong>{{ model_verbose_name }}</strong>
-            {% trans 'will also permanently delete all its related' %} <strong
-            >{{ related_verbose_name_plural }}</strong>.
+            {% blocktrans trimmed with model=model_verbose_name related=related_verbose_name_plural %}Permanently deleting this <strong>{{ model }}</strong> will also permanently delete all its related <strong>{{ related }}</strong>.{% endblocktrans %}
         {% endif %}
         <br>
         {% trans 'Are you sure you want to proceed ?' %}

--- a/horilla/contrib/generics/templates/partials/single_delete/delete_dependency_modal.html
+++ b/horilla/contrib/generics/templates/partials/single_delete/delete_dependency_modal.html
@@ -11,7 +11,7 @@
     <div class="flex justify-between items-center mb-2">
         <h3 class="text-md font-semibold mb-2">
             {% if cannot_delete %}
-                {% trans 'Delete' %} {{ model_verbose_name }} {% trans 'with Dependencies' %}
+                {% blocktrans trimmed with model=model_verbose_name %}Delete {{ model }} with Dependencies{% endblocktrans %}
             {% else %}
                 {% trans 'Confirm Delete' %}
             {% endif %}
@@ -24,8 +24,7 @@
     </div>
     {% if cannot_delete %}
         <p class="text-sm text-gray-600 mb-2">
-            {% trans 'The' %}
-            {{ model_verbose_name }} "{{ object }}" {% trans 'has dependencies and cannot be deleted directly.' %}
+            {% blocktrans trimmed with model=model_verbose_name obj=object %}The {{ model }} "{{ obj }}" has dependencies and cannot be deleted directly.{% endblocktrans %}
         </p>
         <div class="border border-primary-300 rounded-md bg-white mb-3">
             {% for item in cannot_delete %}
@@ -162,7 +161,7 @@
         </div>
     {% else %}
         <p class="text-sm text-gray-600 mb-4">
-            {% trans 'Are you sure you want to delete the' %} {{ model_verbose_name }} "{{ object }}"?
+            {% blocktrans trimmed with model=model_verbose_name obj=object %}Are you sure you want to delete the {{ model }} "{{ obj }}"?{% endblocktrans %}
         </p>
         <div class="flex justify-end gap-2">
             <button onclick="closeModal()" class="text-sm px-6 py-2 bg-[#f11633] rounded-md text-[white]">

--- a/horilla/contrib/generics/templates/partials/single_delete/delete_mode_modal.html
+++ b/horilla/contrib/generics/templates/partials/single_delete/delete_mode_modal.html
@@ -18,7 +18,7 @@
     </div>
     <div>
         <p class="text-sm text-[#474747] mb-3">
-            {% trans 'Choose the deletion mode for' %} {{ model_verbose_name }} "{{ object }}".
+            {% blocktrans trimmed with model=model_verbose_name obj=object %}Choose the deletion mode for {{ model }} "{{ obj }}".{% endblocktrans %}
         </p>
         <div class="mt-3 mb-3 p-3 bg-yellow-50 border border-[#f3edb0] rounded-lg">
             <div class="text-xs text-yellow-800">

--- a/horilla/contrib/generics/templates/partials/single_delete/individual_reassign_form.html
+++ b/horilla/contrib/generics/templates/partials/single_delete/individual_reassign_form.html
@@ -12,9 +12,7 @@
         </button>
     </div>
     <p class="text-sm text-gray-600 mb-4">
-        {% trans 'Choose actions for each dependent' %}
-        {{ model_verbose_name }}
-        {% trans 'before deleting' %} "{{ object }}".
+        {% blocktrans trimmed with model=model_verbose_name obj=object %}Choose actions for each dependent {{ model }} before deleting "{{ obj }}".{% endblocktrans %}
     </p>
 
     <form

--- a/horilla/contrib/generics/templates/partials/soft_delete_form.html
+++ b/horilla/contrib/generics/templates/partials/soft_delete_form.html
@@ -4,7 +4,7 @@
     </div>
     {% if not cannot_delete %}
         <p class="text-sm text-gray-600 mb-4">
-            {% trans 'Are you sure you want to soft delete the selected' %} {{ model_verbose_name }}?
+            {% blocktrans trimmed with model=model_verbose_name %}Are you sure you want to soft delete the selected {{ model }}?{% endblocktrans %}
         </p>
     {% endif %}
     <p class="text-sm text-gray-600 mb-2">

--- a/horilla/contrib/generics/templates/split_view.html
+++ b/horilla/contrib/generics/templates/split_view.html
@@ -137,7 +137,7 @@
                     </p>
                 {% else %}
                     <p class="text-sm text-center pb-3">
-                        {% trans ' Nothing to show yet. Please add your' %} {{ model_verbose_name }}.
+                        {% empty_add_message model_verbose_name %}
                     </p>
                 {% endif %}
                 {% if view_type|slice:":11" == "saved_list_" and saved_list_is_owner %}

--- a/horilla/contrib/generics/templates/timeline_view.html
+++ b/horilla/contrib/generics/templates/timeline_view.html
@@ -346,7 +346,7 @@
             {% elif has_active_filters %}
                 {% trans 'No matching records found. Try adjusting your search or filters.' %}
             {% else %}
-                {% trans "Nothing to show yet. Please add your" %} {{ model_verbose_name }}.
+                {% empty_add_message model_verbose_name %}
             {% endif %}
         </p>
 

--- a/horilla/contrib/generics/templatetags/horilla_tags/misc_tags.py
+++ b/horilla/contrib/generics/templatetags/horilla_tags/misc_tags.py
@@ -1,10 +1,21 @@
 """Miscellaneous template tags."""
 
+from django.utils.encoding import force_str
+
 # First party imports (Horilla)
 from horilla.auth.models import User
+from horilla.utils.translation import gettext as _
 
 # Local imports
 from ._registry import register
+
+
+@register.simple_tag
+def empty_add_message(model_verbose_name):
+    """Complete empty-state sentence with the translated model name interpolated."""
+    return _("Nothing to show yet. Please add your %(model)s.") % {
+        "model": force_str(model_verbose_name)
+    }
 
 
 @register.simple_tag

--- a/horilla/contrib/generics/views/delete.py
+++ b/horilla/contrib/generics/views/delete.py
@@ -8,6 +8,7 @@ import json
 import logging
 
 from django.contrib import messages
+from django.utils.encoding import force_str
 
 # Third-party imports (Django)
 from django.views.generic import DeleteView
@@ -42,7 +43,7 @@ class HorillaSingleDeleteView(DeleteDependencyMixin, DeleteReassignMixin, Delete
 
     template_name = None
     success_url = None
-    success_message = "The record was deleted successfully."
+    success_message = _("The record was deleted successfully.")
     reassign_all_visibility = True
     check_delete_permission = True
     reassign_individual_visibility = True
@@ -138,7 +139,9 @@ class HorillaSingleDeleteView(DeleteDependencyMixin, DeleteReassignMixin, Delete
                     context,
                 )
 
-            cannot_delete, can_delete, _ = self._check_dependencies(record_id)
+            cannot_delete, can_delete, _dependency_details = self._check_dependencies(
+                record_id
+            )
             available_targets = self.model.all_objects.exclude(id=record_id)
             dep_records, related_model, is_nullable, has_more_individual = (
                 self._dependent_records_from_cannot_delete(cannot_delete)
@@ -161,14 +164,14 @@ class HorillaSingleDeleteView(DeleteDependencyMixin, DeleteReassignMixin, Delete
 
             if action == "show_individual_reassign":
                 # Load all dependent records for bulk actions (table view)
-                cannot_delete_all, _, _ = self._check_dependencies(
-                    record_id, get_all=True
+                cannot_delete_all, _can_delete_all, _dependency_details = (
+                    self._check_dependencies(record_id, get_all=True)
                 )
                 (
                     all_dep_records,
-                    _,
-                    _,
-                    _,
+                    _related_model,
+                    _is_nullable,
+                    _has_more,
                 ) = self._dependent_records_from_cannot_delete(
                     cannot_delete_all, limit=None
                 )
@@ -255,10 +258,12 @@ class HorillaSingleDeleteView(DeleteDependencyMixin, DeleteReassignMixin, Delete
                     if is_owner:
                         return obj
                 raise PermissionDenied(
-                    f"You don't have permission to delete this {self.model._meta.verbose_name}."
+                    _("You don't have permission to delete this %(model)s.")
+                    % {"model": force_str(self.model._meta.verbose_name)}
                 )
             raise PermissionDenied(
-                f"You don't have permission to delete {self.model._meta.verbose_name_plural}."
+                _("You don't have permission to delete %(model)s.")
+                % {"model": force_str(self.model._meta.verbose_name_plural)}
             )
         return obj
 
@@ -278,7 +283,7 @@ class HorillaSingleDeleteView(DeleteDependencyMixin, DeleteReassignMixin, Delete
             delete_mode = request.POST.get("delete_mode")
             action = request.POST.get("action")
             check_dependencies = request.POST.get("check_dependencies", "true")
-            cannot_delete, can_delete, _ = [], [], {}
+            cannot_delete, can_delete, _dependency_details = [], [], {}
 
             if not delete_mode and action != "check_dependencies_with_mode":
                 context = {
@@ -318,7 +323,9 @@ class HorillaSingleDeleteView(DeleteDependencyMixin, DeleteReassignMixin, Delete
                     return ScriptResponse(reload=True, extra="closeDeleteModeModal();")
 
             if action == "check_dependencies_with_mode":
-                cannot_delete, can_delete, _ = self._check_dependencies(record_id)
+                cannot_delete, can_delete, _dependency_details = (
+                    self._check_dependencies(record_id)
+                )
                 dep_records, related_model, is_nullable, has_more_individual = (
                     self._dependent_records_from_cannot_delete(cannot_delete)
                 )
@@ -356,7 +363,13 @@ class HorillaSingleDeleteView(DeleteDependencyMixin, DeleteReassignMixin, Delete
                         )
                     messages.success(
                         request,
-                        f"Successfully reassigned {reassigned_count} records and deleted the {self.model._meta.verbose_name}.",
+                        _(
+                            "Successfully reassigned %(count)d records and deleted the %(model)s."
+                        )
+                        % {
+                            "count": reassigned_count,
+                            "model": force_str(self.model._meta.verbose_name),
+                        },
                     )
                     return self.get_post_delete_response()
                 except Exception as e:
@@ -453,8 +466,8 @@ class HorillaSingleDeleteView(DeleteDependencyMixin, DeleteReassignMixin, Delete
                         processed_count = self._perform_individual_action(
                             record_id, actions, delete_mode
                         )
-                        remaining_cannot_delete, _, _ = self._check_dependencies(
-                            record_id
+                        remaining_cannot_delete, _can_delete, _dependency_details = (
+                            self._check_dependencies(record_id)
                         )
                         if not remaining_cannot_delete:
                             self._delete_main_object(
@@ -464,23 +477,33 @@ class HorillaSingleDeleteView(DeleteDependencyMixin, DeleteReassignMixin, Delete
                             if reassigned_count > 0:
                                 messages.success(
                                     request,
-                                    f"Reassigned {reassigned_count} records and deleted {self.object}",
+                                    _(
+                                        "Reassigned %(count)d records and deleted %(record)s"
+                                    )
+                                    % {
+                                        "count": reassigned_count,
+                                        "record": str(self.object),
+                                    },
                                 )
                             else:
                                 messages.success(
                                     request,
-                                    f"Processed dependency records and deleted {self.object}",
+                                    _(
+                                        "Processed dependency records and deleted %(record)s"
+                                    )
+                                    % {"record": str(self.object)},
                                 )
                         elif processed_count > 0:
                             if reassigned_count > 0:
                                 messages.success(
                                     request,
-                                    f"Reassigned {reassigned_count} records",
+                                    _("Reassigned %(count)d records")
+                                    % {"count": reassigned_count},
                                 )
                             else:
                                 messages.success(
                                     request,
-                                    "Processed dependency records",
+                                    _("Processed dependency records"),
                                 )
                     return HxTriggerResponse(
                         extra="closeModal();closeDeleteModal();closeDeleteModeModal();",
@@ -545,7 +568,8 @@ class HorillaSingleDeleteView(DeleteDependencyMixin, DeleteReassignMixin, Delete
                             record_to_delete.delete()
                             messages.success(
                                 request,
-                                f"Successfully deleted {str(record_to_delete)}.",
+                                _("Successfully deleted %(record)s.")
+                                % {"record": str(record_to_delete)},
                             )
                             return ScriptResponse(msgs=True)
                     return HttpResponse("Record not found", status=404)
@@ -568,7 +592,10 @@ class HorillaSingleDeleteView(DeleteDependencyMixin, DeleteReassignMixin, Delete
                         )
                     messages.success(
                         request,
-                        f"Successfully deleted the {self.model._meta.verbose_name} and all its related records.",
+                        _(
+                            "Successfully deleted the %(model)s and all its related records."
+                        )
+                        % {"model": force_str(self.model._meta.verbose_name)},
                     )
                     return self.get_post_delete_response()
                 except Exception as e:
@@ -612,7 +639,7 @@ class HorillaSingleDeleteView(DeleteDependencyMixin, DeleteReassignMixin, Delete
                     return HttpResponse("No record ID provided", status=400)
                 try:
                     with transaction.atomic():
-                        _ = self.model.all_objects.get(id=main_record_id)
+                        self.model.all_objects.get(id=main_record_id)
                         related_objects = self.model._meta.related_objects
                         excluded_models = self._get_excluded_models()
                         updated = False
@@ -646,11 +673,11 @@ class HorillaSingleDeleteView(DeleteDependencyMixin, DeleteReassignMixin, Delete
 
                         if updated:
                             messages.success(
-                                request, "Successfully set record to null."
+                                request, _("Successfully set record to null.")
                             )
 
-                        cannot_delete, can_delete, _ = self._check_dependencies(
-                            main_record_id
+                        cannot_delete, can_delete, _dependency_details = (
+                            self._check_dependencies(main_record_id)
                         )
                         dep_records, related_model, is_nullable, has_more_individual = (
                             self._dependent_records_from_cannot_delete(cannot_delete)
@@ -673,14 +700,14 @@ class HorillaSingleDeleteView(DeleteDependencyMixin, DeleteReassignMixin, Delete
                             request.GET.get("view_id", f"delete_{main_record_id}"),
                         )
                         if cannot_delete:
-                            cannot_delete_all, _, _ = self._check_dependencies(
-                                main_record_id, get_all=True
+                            cannot_delete_all, _can_delete_all, _dependency_details = (
+                                self._check_dependencies(main_record_id, get_all=True)
                             )
                             (
                                 all_dep_records,
-                                _,
-                                _,
-                                _,
+                                _related_model,
+                                _is_nullable,
+                                _has_more,
                             ) = self._dependent_records_from_cannot_delete(
                                 cannot_delete_all, limit=None
                             )
@@ -709,7 +736,9 @@ class HorillaSingleDeleteView(DeleteDependencyMixin, DeleteReassignMixin, Delete
                         status=500,
                     )
 
-            cannot_delete, can_delete, _ = self._check_dependencies(record_id)
+            cannot_delete, can_delete, _dependency_details = self._check_dependencies(
+                record_id
+            )
             if not cannot_delete:
                 dep_records, related_model = [], None
                 available_targets = self.model.all_objects.exclude(id=record_id)
@@ -733,14 +762,17 @@ class HorillaSingleDeleteView(DeleteDependencyMixin, DeleteReassignMixin, Delete
                     context,
                 )
 
-            messages.error(self.request, "Error in delete method")
+            messages.error(self.request, _("Error in delete method"))
             return ScriptResponse(
                 reload=True, extra="closeDeleteModeModal();", close=True
             )
 
         except Exception as e:
             logger.error("Error in delete method: %s", str(e))
-            messages.error(self.request, f"Error in delete method: {str(e)}")
+            messages.error(
+                self.request,
+                _("Error in delete method: %(error)s") % {"error": str(e)},
+            )
             return ScriptResponse(reload=True, extra="closeDeleteModeModal();")
 
     def get_post_delete_response(self):

--- a/horilla/contrib/generics/views/toolkit/bulk_delete.py
+++ b/horilla/contrib/generics/views/toolkit/bulk_delete.py
@@ -741,8 +741,8 @@ class HorillaBulkDeleteMixin:
                         f"{related_model._meta.verbose_name_plural} ({len(dependent_records)})"
                     )
 
-            cannot_delete, can_delete, _ = HorillaBulkDeleteMixin._check_dependencies(
-                self, selected_data
+            cannot_delete, can_delete, _dependency_details = (
+                HorillaBulkDeleteMixin._check_dependencies(self, selected_data)
             )
 
             can_delete_count = len(can_delete)
@@ -839,8 +839,8 @@ class HorillaBulkDeleteMixin:
                         dep_record.delete()
                         deleted_count += 1
 
-            cannot_delete, can_delete, _ = HorillaBulkDeleteMixin._check_dependencies(
-                self, selected_data
+            cannot_delete, can_delete, _dependency_details = (
+                HorillaBulkDeleteMixin._check_dependencies(self, selected_data)
             )
 
             can_delete_count = len(can_delete)

--- a/horilla/contrib/process/approvals/locale/fa/LC_MESSAGES/django.po
+++ b/horilla/contrib/process/approvals/locale/fa/LC_MESSAGES/django.po
@@ -4,21 +4,21 @@
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 #
 msgid ""
-msgstr ""
+msgstr "ماژول پیدا نشد: رکورد مرتبط دیگر وجود ندارد. درخواست تأیید حذف شده است."
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2026-08-18 14:05+0000\n"
-"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"PO-Revision-Date: 2026-08-24 12:00+0330\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
-"Language: \n"
+"Language: fa\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
 msgid "Approvals"
-msgstr ""
+msgstr "تأییدها"
 
 #, python-format
 msgid ""
@@ -27,130 +27,130 @@ msgid ""
 msgstr ""
 
 msgid "Select action"
-msgstr ""
+msgstr "انتخاب اقدام"
 
 msgid "Edit field"
-msgstr ""
+msgstr "ویرایش فیلد"
 
 msgid "Assign task"
-msgstr ""
+msgstr "تخصیص وظیفه"
 
 msgid "Mail"
-msgstr ""
+msgstr "ایمیل"
 
 msgid "Notification"
-msgstr ""
+msgstr "اعلان"
 
 msgid "Approval: field to update"
-msgstr ""
+msgstr "تأیید: فیلد مورد به‌روزرسانی"
 
 msgid "Ex: status"
-msgstr ""
+msgstr "مثال: وضعیت"
 
 msgid "Approval: updated value"
-msgstr ""
+msgstr "تأیید: مقدار به‌روزشده"
 
 msgid "Ex: Approved"
-msgstr ""
+msgstr "مثال: تأیید شده"
 
 msgid "Approval: task title"
-msgstr ""
+msgstr "تأیید: عنوان وظیفه"
 
 msgid "Follow up with requester"
-msgstr ""
+msgstr "پیگیری با درخواست‌دهنده"
 
 msgid "Approval: task description"
-msgstr ""
+msgstr "تأیید: توضیحات وظیفه"
 
 msgid "Rejection: field to update"
-msgstr ""
+msgstr "رد: فیلد مورد به‌روزرسانی"
 
 msgid "Rejection: updated value"
-msgstr ""
+msgstr "رد: مقدار به‌روزشده"
 
 msgid "Ex: Rejected"
-msgstr ""
+msgstr "مثال: رد شده"
 
 msgid "Rejection: task title"
-msgstr ""
+msgstr "رد: عنوان وظیفه"
 
 msgid "Resolve and resubmit"
-msgstr ""
+msgstr "رفع مشکل و ارسال مجدد"
 
 msgid "Rejection: task description"
-msgstr ""
+msgstr "رد: توضیحات وظیفه"
 
 msgid "Approval: email subject"
-msgstr ""
+msgstr "تأیید: موضوع ایمیل"
 
 msgid "Approval: email body"
-msgstr ""
+msgstr "تأیید: متن ایمیل"
 
 msgid "Rejection: email subject"
-msgstr ""
+msgstr "رد: موضوع ایمیل"
 
 msgid "Rejection: email body"
-msgstr ""
+msgstr "رد: متن ایمیل"
 
 msgid "Ex: manager"
-msgstr ""
+msgstr "مثال: مدیر"
 
 msgid "User"
-msgstr ""
+msgstr "کاربر"
 
 msgid "Role"
-msgstr ""
+msgstr "نقش"
 
 msgid "Record owner"
-msgstr ""
+msgstr "مالک رکورد"
 
 msgid "Select role"
-msgstr ""
+msgstr "انتخاب نقش"
 
 msgid "Approval Processes"
-msgstr ""
+msgstr "فرآیندهای تأیید"
 
 msgid "Approval Jobs"
-msgstr ""
+msgstr "کارهای تأیید"
 
 msgid "Name"
-msgstr ""
+msgstr "نام"
 
 msgid "Model this process applies to."
-msgstr ""
+msgstr "مدلی که این فرآیند روی آن اعمال می‌شود."
 
 msgid "Module"
-msgstr ""
+msgstr "ماژول"
 
 msgid "When record is created"
-msgstr ""
+msgstr "هنگام ایجاد رکورد"
 
 msgid "Run this process when a new record is created."
-msgstr ""
+msgstr "این فرآیند هنگام ایجاد رکورد جدید اجرا شود."
 
 msgid "When record is edited"
-msgstr ""
+msgstr "هنگام ویرایش رکورد"
 
 msgid "Run this process when a record is edited."
-msgstr ""
+msgstr "این فرآیند هنگام ویرایش رکورد اجرا شود."
 
 msgid "Create and Edit"
-msgstr ""
+msgstr "ایجاد و ویرایش"
 
 msgid "Create only"
-msgstr ""
+msgstr "فقط ایجاد"
 
 msgid "Edit only"
-msgstr ""
+msgstr "فقط ویرایش"
 
 msgid "Not set"
-msgstr ""
+msgstr "تنظیم نشده"
 
 msgid "Approval process"
-msgstr ""
+msgstr "فرآیند تأیید"
 
 msgid "Approval processes"
-msgstr ""
+msgstr "فرآیندهای تأیید"
 
 msgid ""
 "Per-rule JSON: approval_actions, rejection_actions, record_modification, "
@@ -158,88 +158,88 @@ msgid ""
 msgstr ""
 
 msgid "Order"
-msgstr ""
+msgstr "ترتیب"
 
 msgid "Sequence of this rule within the process."
-msgstr ""
+msgstr "ترتیب این قانون در فرآیند."
 
 msgid "Approval process rule"
-msgstr ""
+msgstr "قانون فرآیند تأیید"
 
 msgid "Approval process rules"
-msgstr ""
+msgstr "قوانین فرآیند تأیید"
 
 msgid "Rule"
-msgstr ""
+msgstr "قانون"
 
 msgid "Specific user"
-msgstr ""
+msgstr "کاربر مشخص"
 
 msgid "Manager of record owner"
-msgstr ""
+msgstr "مدیر مالک رکورد"
 
 msgid "Sequence order of this step within the rule."
-msgstr ""
+msgstr "ترتیب این مرحله در قانون."
 
 msgid "Identifier for the role (implementation-specific)."
-msgstr ""
+msgstr "شناسه نقش (وابسته به پیاده‌سازی)."
 
 msgid "Approval step"
-msgstr ""
+msgstr "مرحله تأیید"
 
 msgid "Approval steps"
-msgstr ""
+msgstr "مراحل تأیید"
 
 msgid "step"
-msgstr ""
+msgstr "مرحله"
 
 msgid "Process rule"
-msgstr ""
+msgstr "قانون فرآیند"
 
 msgid "Field Name"
-msgstr ""
+msgstr "نام فیلد"
 
 msgid "Operator"
-msgstr ""
+msgstr "عملگر"
 
 msgid "Value"
-msgstr ""
+msgstr "مقدار"
 
 msgid "AND"
-msgstr ""
+msgstr "و"
 
 msgid "OR"
-msgstr ""
+msgstr "یا"
 
 msgid "Logical Operator"
-msgstr ""
+msgstr "عملگر منطقی"
 
 msgid "Approval Condition"
-msgstr ""
+msgstr "شرط تأیید"
 
 msgid "Approval Conditions"
-msgstr ""
+msgstr "شروط تأیید"
 
 msgid "Pending"
-msgstr ""
+msgstr "در انتظار"
 
 msgid "Approved"
-msgstr ""
+msgstr "تأیید شده"
 
 msgid "Rejected"
-msgstr ""
+msgstr "رد شده"
 
 msgid "Cancelled"
-msgstr ""
+msgstr "لغو شده"
 
 msgid "Primary key of the target object, stored as string."
-msgstr ""
+msgstr "کلید اصلی شیء هدف که به‌صورت رشته ذخیره می‌شود."
 
 msgid "Status"
-msgstr ""
+msgstr "وضعیت"
 
 msgid "The step currently awaiting decision, if any."
-msgstr ""
+msgstr "مرحله‌ای که در حال حاضر منتظر تصمیم است، در صورت وجود."
 
 msgid ""
 "When set, overrides current_step's approver for this instance only, without "
@@ -247,232 +247,232 @@ msgid ""
 msgstr ""
 
 msgid "Approval instance"
-msgstr ""
+msgstr "نمونه تأیید"
 
 msgid "Approval instances"
-msgstr ""
+msgstr "نمونه‌های تأیید"
 
 msgid "Approve"
-msgstr ""
+msgstr "تأیید"
 
 msgid "Reject"
-msgstr ""
+msgstr "رد"
 
 msgid "Approval decision"
-msgstr ""
+msgstr "تصمیم تأیید"
 
 msgid "Approval decisions"
-msgstr ""
+msgstr "تصمیم‌های تأیید"
 
 msgid "This record is pending approval and cannot be edited."
-msgstr ""
+msgstr "این رکورد در انتظار تأیید است و نمی‌توان آن را ویرایش کرد."
 
 msgid "Record has been submitted for approval."
-msgstr ""
+msgstr "رکورد برای تأیید ارسال شد."
 
 msgid "Configure approval action"
-msgstr ""
+msgstr "پیکربندی اقدام تأیید"
 
 msgid "Configure rejection action"
-msgstr ""
+msgstr "پیکربندی اقدام رد"
 
 msgid "Field"
-msgstr ""
+msgstr "فیلد"
 
 msgid "Select field"
-msgstr ""
+msgstr "انتخاب فیلد"
 
 msgid "Task title"
-msgstr ""
+msgstr "عنوان وظیفه"
 
 msgid "Due basis"
-msgstr ""
+msgstr "مبنای سررسید"
 
 msgid "Record submission date"
-msgstr ""
+msgstr "تاریخ ثبت رکورد"
 
 msgid "Approval date"
-msgstr ""
+msgstr "تاریخ تأیید"
 
 msgid "Rejection date"
-msgstr ""
+msgstr "تاریخ رد"
 
 msgid "Due in days"
-msgstr ""
+msgstr "سررسید در روز"
 
 msgid "Not Started"
-msgstr ""
+msgstr "شروع نشده"
 
 msgid "In Progress"
-msgstr ""
+msgstr "در حال انجام"
 
 msgid "Completed"
-msgstr ""
+msgstr "تکمیل شده"
 
 msgid "Priority"
-msgstr ""
+msgstr "اولویت"
 
 msgid "Low"
-msgstr ""
+msgstr "پایین"
 
 msgid "Medium"
-msgstr ""
+msgstr "متوسط"
 
 msgid "High"
-msgstr ""
+msgstr "بالا"
 
 msgid "Task description"
-msgstr ""
+msgstr "توضیحات وظیفه"
 
 msgid "Mail template"
-msgstr ""
+msgstr "قالب ایمیل"
 
 msgid "Select template"
-msgstr ""
+msgstr "انتخاب قالب"
 
 msgid "To (email field / email / self)"
-msgstr ""
+msgstr "به (فیلد ایمیل / ایمیل / خود)"
 
 msgid "Also send to"
-msgstr ""
+msgstr "همچنین ارسال به"
 
 msgid "Notification template"
-msgstr ""
+msgstr "قالب اعلان"
 
 msgid "To (record field / self)"
-msgstr ""
+msgstr "به (فیلد رکورد / خود)"
 
 msgid "Also notify to"
-msgstr ""
+msgstr "همچنین اعلان به"
 
 msgid "Custom message (optional, overrides template)"
-msgstr ""
+msgstr "پیام سفارشی (اختیاری، بازنویسی قالب)"
 
 msgid "Cancel"
-msgstr ""
+msgstr "لغو"
 
 msgid "Apply"
-msgstr ""
+msgstr "اعمال"
 
 msgid "Select value"
-msgstr ""
+msgstr "انتخاب مقدار"
 
 msgid "Approval History"
-msgstr ""
+msgstr "تاریخچه تأیید"
 
 msgid "Resubmit this record for approval?"
-msgstr ""
+msgstr "آیا این رکورد برای تأیید مجدد ارسال شود؟"
 
 msgid "Resubmit"
-msgstr ""
+msgstr "ارسال مجدد"
 
 msgid "Process"
-msgstr ""
+msgstr "فرآیند"
 
 msgid "Requested By"
-msgstr ""
+msgstr "درخواست‌دهنده"
 
 msgid "Respond"
-msgstr ""
+msgstr "پاسخ"
 
 msgid "Current Step"
-msgstr ""
+msgstr "مرحله فعلی"
 
 msgid "Completed Steps"
-msgstr ""
+msgstr "مراحل تکمیل‌شده"
 
 msgid "Progress"
-msgstr ""
+msgstr "پیشرفت"
 
 msgid "Respond to Approval"
-msgstr ""
+msgstr "پاسخ به درخواست تأیید"
 
 msgid "Close"
-msgstr ""
+msgstr "بستن"
 
 msgid "Decision"
-msgstr ""
+msgstr "تصمیم"
 
 msgid "Delegate"
-msgstr ""
+msgstr "واگذاری"
 
 msgid "Delegate To"
-msgstr ""
+msgstr "واگذاری به"
 
 msgid "Select user"
-msgstr ""
+msgstr "انتخاب کاربر"
 
 msgid "Response Note (Optional)"
-msgstr ""
+msgstr "یادداشت پاسخ (اختیاری)"
 
 msgid "Add comments for your decision"
-msgstr ""
+msgstr "برای تصمیم خود توضیحاتی اضافه کنید"
 
 msgid "Submit Response"
-msgstr ""
+msgstr "ثبت پاسخ"
 
 msgid "Execute on"
-msgstr ""
+msgstr "اجرا بر روی"
 
 msgid "Edit"
-msgstr ""
+msgstr "ویرایش"
 
 msgid "Delete"
-msgstr ""
+msgstr "حذف"
 
 msgid "Conditions"
-msgstr ""
+msgstr "شروط"
 
 msgid "Approver"
-msgstr ""
+msgstr "تأییدکننده"
 
 msgid "Notify approver"
-msgstr ""
+msgstr "اطلاع‌رسانی به تأییدکننده"
 
 msgid "Email"
-msgstr ""
+msgstr "ایمیل"
 
 msgid "On approval"
-msgstr ""
+msgstr "در صورت تأیید"
 
 msgid "Actions"
-msgstr ""
+msgstr "اقدامات"
 
 msgid "Template"
-msgstr ""
+msgstr "قالب"
 
 msgid "To"
-msgstr ""
+msgstr "تا"
 
 msgid "Custom message"
-msgstr ""
+msgstr "پیام سفارشی"
 
 msgid "On rejection"
-msgstr ""
+msgstr "در صورت رد"
 
 msgid "Record modification"
-msgstr ""
+msgstr "تغییر رکورد"
 
 msgid "Stage"
-msgstr ""
+msgstr "مرحله"
 
 msgid "While waiting for approval"
-msgstr ""
+msgstr "در زمان انتظار برای تأیید"
 
 msgid "All Fields"
-msgstr ""
+msgstr "همه فیلدها"
 
 msgid "No Fields"
-msgstr ""
+msgstr "بدون فیلد"
 
 msgid "When record is in rejected state"
-msgstr ""
+msgstr "هنگامی که رکورد در وضعیت رد شده است"
 
 msgid "No process rules yet. Use Add rule in the header above."
-msgstr ""
+msgstr "هنوز هیچ قانون فرآیندی وجود ندارد. از گزینه «افزودن قانون» در سربرگ بالا استفاده کنید."
 
 msgid "Are you sure you want to deactivate this approval process?"
-msgstr ""
+msgstr "آیا مطمئن هستید که می‌خواهید این فرآیند تأیید را غیرفعال کنید؟"
 
 #, python-format
 msgid ""
@@ -481,61 +481,61 @@ msgid ""
 msgstr ""
 
 msgid "Action on approval"
-msgstr ""
+msgstr "اقدام در صورت تأیید"
 
 msgid "Selected:"
-msgstr ""
+msgstr "انتخاب‌شده:"
 
 msgid "Edit Field"
-msgstr ""
+msgstr "ویرایش فیلد"
 
 msgid "Assign Task"
-msgstr ""
+msgstr "تخصیص وظیفه"
 
 msgid "Action on rejection"
-msgstr ""
+msgstr "اقدام در صورت رد"
 
 msgid "Who should approve"
-msgstr ""
+msgstr "چه کسی باید تأیید کند؟"
 
 msgid "Approver type"
-msgstr ""
+msgstr "نوع تأییدکننده"
 
 msgid "Approver will be resolved from the record owner at runtime."
-msgstr ""
+msgstr "تأییدکننده در زمان اجرا بر اساس مالک رکورد تعیین می‌شود."
 
 msgid "Add More Approvers"
-msgstr ""
+msgstr "افزودن تأییدکنندگان بیشتر"
 
 msgid "Set overall approval method"
-msgstr ""
+msgstr "تعیین روش کلی تأیید"
 
 msgid "Anyone"
-msgstr ""
+msgstr "هرکدام"
 
 msgid "Everyone"
-msgstr ""
+msgstr "همه"
 
 msgid "Specify the order"
-msgstr ""
+msgstr "تعیین ترتیب"
 
 msgid "Sequential"
-msgstr ""
+msgstr "ترتیبی"
 
 msgid "Parallel"
-msgstr ""
+msgstr "هم‌زمان"
 
 msgid "Record Modification"
 msgstr ""
 
 msgid "Configure field access per approval stage (sequential approval)."
-msgstr ""
+msgstr "دسترسی به فیلدها را برای هر مرحله تأیید پیکربندی کنید (تأیید ترتیبی)."
 
 msgid "Field access"
-msgstr ""
+msgstr "دسترسی به فیلد"
 
 msgid "Specific Fields"
-msgstr ""
+msgstr "فیلدهای مشخص"
 
 msgid ""
 "One setting applies to the whole process (Anyone, Parallel, or a single "
@@ -543,25 +543,25 @@ msgid ""
 msgstr ""
 
 msgid "Edit Policy While Waiting"
-msgstr ""
+msgstr "سیاست ویرایش در زمان انتظار"
 
 msgid "All fields are editable."
-msgstr ""
+msgstr "همه فیلدها قابل ویرایش هستند."
 
 msgid "Only specific fields are editable"
-msgstr ""
+msgstr "فقط فیلدهای مشخص قابل ویرایش هستند"
 
 msgid "No fields are editable while waiting."
-msgstr ""
+msgstr "در زمان انتظار هیچ فیلدی قابل ویرایش نیست."
 
 msgid "Select fields"
-msgstr ""
+msgstr "انتخاب فیلدها"
 
 msgid "No fields available"
-msgstr ""
+msgstr "فیلدی در دسترس نیست"
 
 msgid "This approval no longer exists."
-msgstr ""
+msgstr "این درخواست تأیید دیگر وجود ندارد."
 
 msgid ""
 "Module not found: the linked record no longer exists. The approval entry has "
@@ -569,170 +569,170 @@ msgid ""
 msgstr ""
 
 msgid "Only the original requester can resubmit this record."
-msgstr ""
+msgstr "فقط درخواست‌دهنده اصلی می‌تواند این رکورد را مجدداً ارسال کند."
 
 msgid "No approver step configured."
-msgstr ""
+msgstr "هیچ مرحله‌ای برای تأییدکننده پیکربندی نشده است."
 
 msgid "Record resubmitted for approval."
-msgstr ""
+msgstr "رکورد مجدداً برای تأیید ارسال شد."
 
 msgid "Only the original requester can update this task."
-msgstr ""
+msgstr "فقط درخواست‌دهنده اصلی می‌تواند این وظیفه را به‌روزرسانی کند."
 
 msgid "Invalid task status."
-msgstr ""
+msgstr "وضعیت وظیفه نامعتبر است."
 
 msgid "Invalid related record."
-msgstr ""
+msgstr "رکورد مرتبط نامعتبر است."
 
 msgid "Task status updated successfully."
-msgstr ""
+msgstr "وضعیت وظیفه با موفقیت به‌روزرسانی شد."
 
 msgid "Details"
-msgstr ""
+msgstr "جزئیات"
 
 msgid "Decision Timeline"
-msgstr ""
+msgstr "خط زمانی تصمیمات"
 
 msgid "Tasks"
-msgstr ""
+msgstr "وظایف"
 
 msgid "Step"
-msgstr ""
+msgstr "مرحله"
 
 msgid "Cycle"
-msgstr ""
+msgstr "دوره"
 
 msgid "Decided By"
-msgstr ""
+msgstr "تصمیم‌گیرنده"
 
 msgid "Comment"
-msgstr ""
+msgstr "نظر"
 
 msgid "Decided At"
-msgstr ""
+msgstr "زمان تصمیم"
 
 msgid "Current (After Resubmit)"
-msgstr ""
+msgstr "فعلی (پس از ارسال مجدد)"
 
 msgid "Previous"
-msgstr ""
+msgstr "قبلی"
 
 msgid "Current"
-msgstr ""
+msgstr "جاری"
 
 msgid "Subject"
-msgstr ""
+msgstr "موضوع"
 
 msgid "Due Date"
-msgstr ""
+msgstr "تاریخ سررسید"
 
 msgid "My Approval Jobs"
-msgstr ""
+msgstr "کارهای تأیید من"
 
 msgid "You are not an approver for this job."
-msgstr ""
+msgstr "شما تأییدکننده این کار نیستید."
 
 msgid "Module not found: the record linked to this approval no longer exists."
-msgstr ""
+msgstr "ماژول پیدا نشد: رکورد مرتبط با این تأیید دیگر وجود ندارد."
 
 msgid "You are not the approver for this job."
-msgstr ""
+msgstr "شما تأییدکننده این کار نیستید."
 
 msgid "Invalid decision."
-msgstr ""
+msgstr "تصمیم نامعتبر است."
 
 msgid "No pending step found."
-msgstr ""
+msgstr "هیچ مرحله در انتظاری پیدا نشد."
 
 msgid "Approval delegated successfully."
-msgstr ""
+msgstr "تأیید با موفقیت واگذار شد."
 
 msgid "Approval rejected."
-msgstr ""
+msgstr "تأیید رد شد."
 
 msgid "Approved. Waiting for other approvers."
-msgstr ""
+msgstr "تأیید شد. در انتظار سایر تأییدکنندگان."
 
 msgid "Approval completed."
-msgstr ""
+msgstr "فرآیند تأیید تکمیل شد."
 
 msgid "Approved and moved to next approver."
-msgstr ""
+msgstr "تأیید شد و به تأییدکننده بعدی منتقل شد."
 
 msgid "You are not the approver for this pending job."
-msgstr ""
+msgstr "شما تأییدکننده این کار در انتظار نیستید."
 
 msgid "Only the original requester can edit this rejected record."
-msgstr ""
+msgstr "فقط درخواست‌دهنده اصلی می‌تواند این رکورد ردشده را ویرایش کند."
 
 msgid "Only the original requester can edit this approved record."
-msgstr ""
+msgstr "فقط درخواست‌دهنده اصلی می‌تواند این رکورد تأییدشده را ویرایش کند."
 
 msgid "This record's approval status does not allow edits."
-msgstr ""
+msgstr "وضعیت تأیید این رکورد اجازه ویرایش را نمی‌دهد."
 
 msgid "Record not found."
-msgstr ""
+msgstr "رکورد پیدا نشد."
 
 msgid "Invalid field."
-msgstr ""
+msgstr "فیلد نامعتبر است."
 
 msgid "Field is not editable."
-msgstr ""
+msgstr "این فیلد قابل ویرایش نیست."
 
 msgid "Unknown field."
-msgstr ""
+msgstr "فیلد ناشناخته است."
 
 msgid "Invalid value."
-msgstr ""
+msgstr "مقدار نامعتبر است."
 
 msgid "Failed to update field."
-msgstr ""
+msgstr "به‌روزرسانی فیلد ناموفق بود."
 
 msgid "Field updated successfully."
-msgstr ""
+msgstr "فیلد با موفقیت به‌روزرسانی شد."
 
 msgid "Model"
-msgstr ""
+msgstr "مدل"
 
 msgid "Active"
-msgstr ""
+msgstr "فعال"
 
 msgid "Approval Process"
-msgstr ""
+msgstr "فرآیند تأیید"
 
 msgid "Rule criteria"
-msgstr ""
+msgstr "شرایط قانون"
 
 msgid "When should this rule apply?"
-msgstr ""
+msgstr "این قانون چه زمانی باید اعمال شود؟"
 
 #, python-format
 msgid "Rule %(order)s — Criteria"
-msgstr ""
+msgstr "قانون %(order)s — شرایط"
 
 msgid "Add process rule"
-msgstr ""
+msgstr "افزودن قانون فرآیند"
 
 msgid "Edit process rule"
-msgstr ""
+msgstr "ویرایش قانون فرآیند"
 
 msgid "A rule with this order already exists for this process."
-msgstr ""
+msgstr "قانونی با این ترتیب از قبل برای این فرآیند وجود دارد."
 
 msgid "Process rule updated successfully."
-msgstr ""
+msgstr "قانون فرآیند با موفقیت به‌روزرسانی شد."
 
 msgid "Process rule created successfully."
-msgstr ""
+msgstr "قانون فرآیند با موفقیت ایجاد شد."
 
 msgid "activated"
-msgstr ""
+msgstr "فعال شد"
 
 msgid "deactivated"
-msgstr ""
+msgstr "غیرفعال شد"
 
 #, python-format
 msgid ""
@@ -741,7 +741,7 @@ msgid ""
 msgstr ""
 
 msgid "Add Rule"
-msgstr ""
+msgstr "افزودن قانون"
 
 msgid "Edit Process"
-msgstr ""
+msgstr "ویرایش فرآیند"

--- a/horilla/contrib/process/reviews/locale/fa/LC_MESSAGES/django.po
+++ b/horilla/contrib/process/reviews/locale/fa/LC_MESSAGES/django.po
@@ -8,357 +8,360 @@ msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2026-08-18 14:05+0000\n"
-"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"PO-Revision-Date: 2026-08-24 12:00+0330\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
-"Language: \n"
+"Language: fa\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
 msgid "Review Process"
-msgstr ""
+msgstr "فرآیند بازبینی"
 
 msgid "Select field(s)"
-msgstr ""
+msgstr "انتخاب فیلد(ها)"
 
 msgid "Fields to Review"
-msgstr ""
+msgstr "فیلدهای بازبینی"
 
 msgid "Please select at least one field to review."
-msgstr ""
+msgstr "لطفاً حداقل یک فیلد برای بازبینی انتخاب کنید."
 
 msgid "Please select at least one approver user."
-msgstr ""
+msgstr "لطفاً حداقل یک کاربر تأییدکننده انتخاب کنید."
 
 msgid "Please select at least one approver role."
-msgstr ""
+msgstr "لطفاً حداقل یک نقش تأییدکننده انتخاب کنید."
 
 msgid "Review Processes"
-msgstr ""
+msgstr "فرآیندهای بازبینی"
 
 msgid "Review Jobs"
-msgstr ""
+msgstr "کارهای بازبینی"
 
 msgid "Title"
-msgstr ""
+msgstr "عنوان"
 
 msgid "Method Title"
-msgstr ""
+msgstr "عنوان روش"
 
 msgid "Module"
-msgstr ""
+msgstr "ماژول"
 
 msgid "Notify on Resubmission"
-msgstr ""
+msgstr "اعلان در ارسال مجدد"
 
 msgid "Notify on Approval"
-msgstr ""
+msgstr "اعلان در تأیید"
 
 msgid "Notify on Rejection"
-msgstr ""
+msgstr "اعلان در رد"
 
 msgid "Title is required."
-msgstr ""
+msgstr "عنوان الزامی است."
 
 msgid ""
 "An active review process already exists for this model and company. Only one "
 "active process is allowed per model per company."
-msgstr ""
+msgstr "یک فرآیند بازبینی فعال برای این مدل و شرکت وجود دارد. فقط یک فرآیند فعال در هر مدل و هر شرکت مجاز است."
 
 msgid "Field Name"
-msgstr ""
+msgstr "نام فیلد"
 
 msgid "Operator"
-msgstr ""
+msgstr "عملگر"
 
 msgid "Value"
-msgstr ""
+msgstr "مقدار"
 
 msgid "AND"
-msgstr ""
+msgstr "و"
 
 msgid "OR"
-msgstr ""
+msgstr "یا"
 
 msgid "Logical Operator"
-msgstr ""
+msgstr "عملگر منطقی"
 
 msgid "Order"
-msgstr ""
+msgstr "ترتیب"
 
 msgid "Review Condition"
-msgstr ""
+msgstr "شرط بازبینی"
 
 msgid "Review Conditions"
-msgstr ""
+msgstr "شروط بازبینی"
 
 msgid "User"
-msgstr ""
+msgstr "کاربر"
 
 msgid "Role"
-msgstr ""
+msgstr "نقش"
 
 msgid "Approver Type"
-msgstr ""
+msgstr "نوع تأییدکننده"
 
 msgid "Approver Users"
-msgstr ""
+msgstr "کاربران تأییدکننده"
 
 msgid "Approver Roles"
-msgstr ""
+msgstr "نقش‌های تأییدکننده"
 
 msgid "Review Rule"
-msgstr ""
+msgstr "قانون بازبینی"
 
 msgid "Review Rules"
-msgstr ""
+msgstr "قوانین بازبینی"
 
 msgid "Review Rule Condition"
-msgstr ""
+msgstr "شرط قانون بازبینی"
 
 msgid "Review Rule Conditions"
-msgstr ""
+msgstr "شروط قانون بازبینی"
 
 msgid "Pending"
-msgstr ""
+msgstr "در انتظار"
 
 msgid "Approved"
-msgstr ""
+msgstr "تأیید شده"
 
 msgid "Rejected"
-msgstr ""
+msgstr "رد شده"
 
 msgid "Content Type"
-msgstr ""
+msgstr "نوع محتوا"
 
 msgid "Object ID"
-msgstr ""
+msgstr "شناسه شیء"
 
 msgid "Assigned To"
-msgstr ""
+msgstr "اختصاص یافته به"
 
 msgid "Review Fields Snapshot"
-msgstr ""
+msgstr "نمای فیلدهای بازبینی"
 
 msgid "Status"
-msgstr ""
+msgstr "وضعیت"
 
 msgid "Reviewed By"
-msgstr ""
+msgstr "بازبینی شده توسط"
 
 msgid "Reviewed At"
-msgstr ""
+msgstr "بازبینی شده در"
 
 msgid "Review Note"
-msgstr ""
+msgstr "یادداشت بازبینی"
 
 msgid "Review Job"
-msgstr ""
+msgstr "کار بازبینی"
 
 msgid "Add More"
-msgstr ""
+msgstr "افزودن بیشتر"
 
 msgid "Field Review"
-msgstr ""
+msgstr "بازبینی فیلد"
 
 msgid "Close"
-msgstr ""
+msgstr "بستن"
 
 msgid "Your Decision"
-msgstr ""
+msgstr "تصمیم شما"
 
 msgid "Comment"
-msgstr ""
+msgstr "نظر"
 
 msgid "Add reason for this field decision"
-msgstr ""
+msgstr "دلیل این تصمیم فیلد را اضافه کنید"
 
 msgid "Reject"
-msgstr ""
+msgstr "رد"
 
 msgid "Approve"
-msgstr ""
+msgstr "تأیید"
 
 msgid "Process"
-msgstr ""
+msgstr "فرآیند"
 
 msgid "Record"
-msgstr ""
+msgstr "رکورد"
 
 #, python-format
 msgid ""
 "\n"
-"                            %(done)s / %(total)s approved.\n"
+"%(done)s / %(total)s approved.\n"
 "                        "
 msgstr ""
+"\n"
+"%(done)s / %(total)s تأیید شده.\n"
+"                        "
 
 msgid "Record Details"
-msgstr ""
+msgstr "جزئیات رکورد"
 
 msgid "No additional record details available."
-msgstr ""
+msgstr "هیچ جزئیات اضافی برای رکورد در دسترس نیست."
 
 msgid "Fields To Review"
-msgstr ""
+msgstr "فیلدهای بازبینی"
 
 msgid "Review field"
-msgstr ""
+msgstr "فیلد بازبینی"
 
 msgid "Edit rejected field"
-msgstr ""
+msgstr "ویرایش فیلد رد شده"
 
 msgid "Edit"
-msgstr ""
+msgstr "ویرایش"
 
 msgid "Save and resubmit"
-msgstr ""
+msgstr "ذخیره و ارسال مجدد"
 
 msgid "Save"
-msgstr ""
+msgstr "ذخیره"
 
 msgid "Cancel"
-msgstr ""
+msgstr "لغو"
 
 msgid "No review fields captured for this job."
-msgstr ""
+msgstr "هیچ فیلد بازبینی برای این کار ثبت نشده است."
 
 msgid "Multi-Step Form"
-msgstr ""
+msgstr "فرم چند مرحله‌ای"
 
 msgid "Single-Step Form"
-msgstr ""
+msgstr "فرم تک مرحله‌ای"
 
 msgid "Choose File"
-msgstr ""
+msgstr "انتخاب فایل"
 
 msgid "No file chosen"
-msgstr ""
+msgstr "هیچ فایلی انتخاب نشده است"
 
 msgid "Clear"
-msgstr ""
+msgstr "پاک کردن"
 
 msgid "Read Only"
-msgstr ""
+msgstr "فقط خواندنی"
 
 msgid "Add"
-msgstr ""
+msgstr "افزودن"
 
 msgid "Loading..."
-msgstr ""
+msgstr "در حال بارگذاری..."
 
 msgid "Conditions"
-msgstr ""
+msgstr "شروط"
 
 msgid "Remove"
-msgstr ""
+msgstr "حذف"
 
 msgid "Save & New"
-msgstr ""
+msgstr "ذخیره و جدید"
 
 msgid "Entry Criteria"
-msgstr ""
+msgstr "معیارهای ورود"
 
 msgid ""
 "No entry criteria set. This review process applies to all records in the "
 "module."
-msgstr ""
+msgstr "هیچ معیار ورودی تنظیم نشده است. این فرآیند بازبینی برای همه رکوردهای ماژول اعمال می‌شود."
 
 msgid "Actions"
-msgstr ""
+msgstr "اقدامات"
 
 msgid "Resubmission"
-msgstr ""
+msgstr "ارسال مجدد"
 
 msgid "Approval"
-msgstr ""
+msgstr "تأیید"
 
 msgid "Rejection"
-msgstr ""
+msgstr "رد"
 
 msgid "Fields"
-msgstr ""
+msgstr "فیلدها"
 
 msgid "No review rules added"
-msgstr ""
+msgstr "هیچ قانون بازبینی اضافه نشده است"
 
 msgid ""
 "Add a rule to assign an approver. Criteria is optional — if left empty, the "
 "rule applies to all records."
-msgstr ""
+msgstr "برای تعیین تأییدکننده، یک قانون اضافه کنید. معیارها اختیاری هستند — در صورت خالی بودن، قانون برای همه رکوردها اعمال می‌شود."
 
 msgid "Rule"
-msgstr ""
+msgstr "قانون"
 
 msgid "Edit Rule"
-msgstr ""
+msgstr "ویرایش قانون"
 
 msgid "Delete Rule"
-msgstr ""
+msgstr "حذف قانون"
 
 msgid "Approver"
-msgstr ""
+msgstr "تأییدکننده"
 
 #, python-format
 msgid "You have a pending review request for %(record)s in %(process)s."
-msgstr ""
+msgstr "شما یک درخواست بازبینی در انتظار برای %(record)s در %(process)s دارید."
 
 msgid "Add Rule"
-msgstr ""
+msgstr "افزودن قانون"
 
 msgid "Edit Process"
-msgstr ""
+msgstr "ویرایش فرآیند"
 
 msgid "Delete"
-msgstr ""
+msgstr "حذف"
 
 msgid "Criteria"
-msgstr ""
+msgstr "معیارها"
 
 msgid "Condition"
-msgstr ""
+msgstr "شرط"
 
 msgid "activated"
-msgstr ""
+msgstr "فعال شد"
 
 msgid "deactivated"
-msgstr ""
+msgstr "غیرفعال شد"
 
 msgid "An active review process already exists for this model and company."
-msgstr ""
+msgstr "یک فرآیند بازبینی فعال برای این مدل و شرکت وجود دارد."
 
 msgid "My Review Jobs"
-msgstr ""
+msgstr "کارهای بازبینی من"
 
 msgid "Review"
-msgstr ""
+msgstr "بازبینی"
 
 msgid "The module for this review record is no longer available."
-msgstr ""
+msgstr "ماژول این رکورد بازبینی دیگر در دسترس نیست."
 
 #, python-format
 msgid "%(owner)s resubmitted %(field)s in %(process)s for %(record)s."
-msgstr ""
+msgstr "%(owner)s %(field)s را در %(process)s برای %(record)s دوباره ارسال کرد."
 
 msgid "Invalid decision."
-msgstr ""
+msgstr "تصمیم نامعتبر است."
 
 #, python-format
 msgid ""
 "%(field)s was approved in %(process)s by %(approver)s. Comment: %(comment)s"
-msgstr ""
+msgstr "%(field)s در %(process)s توسط %(approver)s تأیید شد. نظر: %(comment)s"
 
 #, python-format
 msgid ""
 "%(field)s was rejected in %(process)s by %(approver)s. Reason: %(comment)s"
-msgstr ""
+msgstr "%(field)s در %(process)s توسط %(approver)s رد شد. دلیل: %(comment)s"
 
 msgid ""
 "All approvers have approved all review fields. Review completed successfully."
-msgstr ""
+msgstr "همه تأییدکنندگان همه فیلدهای بازبینی را تأیید کردند. بازبینی با موفقیت انجام شد."
 
 msgid ""
 "You have approved all fields. Waiting for other approvers to complete their "
 "review."
-msgstr ""
+msgstr "شما همه فیلدها را تأیید کرده‌اید. در انتظار تکمیل بازبینی توسط سایر تأییدکنندگان."

--- a/horilla/locale/fa/LC_MESSAGES/django.po
+++ b/horilla/locale/fa/LC_MESSAGES/django.po
@@ -3334,3 +3334,75 @@ msgstr "رمز عبور را وارد کنید"
 
 msgid "Load Demo Data"
 msgstr "بارگذاری داده‌های نمایشی"
+
+#, python-format
+msgid "Nothing to show yet. Please add your %(model)s."
+msgstr "هنوز چیزی برای نمایش وجود ندارد. لطفاً %(model)s را اضافه کنید."
+
+# Roles & Permissions — model section labels
+msgid "Call Integration Setting"
+msgstr "تنظیمات یکپارچه‌سازی تماس"
+
+msgid "Call Integration Settings"
+msgstr "تنظیمات یکپارچه‌سازی تماس"
+
+msgid "Call Provider"
+msgstr "ارائه‌دهنده تماس"
+
+msgid "Call Providers"
+msgstr "ارائه‌دهندگان تماس"
+
+msgid "Call Log"
+msgstr "گزارش تماس"
+
+msgid "Call Logs"
+msgstr "گزارش‌های تماس"
+
+msgid "Agent Mapping"
+msgstr "نگاشت نماینده"
+
+msgid "Agent Mappings"
+msgstr "نگاشت‌های نماینده"
+
+msgid "Approval process"
+msgstr "فرآیند تأیید"
+
+msgid "Approval processes"
+msgstr "فرآیندهای تأیید"
+
+msgid "Approval process rule"
+msgstr "قانون فرآیند تأیید"
+
+msgid "Approval process rules"
+msgstr "قوانین فرآیند تأیید"
+
+msgid "Approval step"
+msgstr "مرحله تأیید"
+
+msgid "Approval steps"
+msgstr "مراحل تأیید"
+
+msgid "Approval instance"
+msgstr "نمونه تأیید"
+
+msgid "Approval instances"
+msgstr "نمونه‌های تأیید"
+
+msgid "Approval decision"
+msgstr "تصمیم تأیید"
+
+msgid "Approval decisions"
+msgstr "تصمیم‌های تأیید"
+
+msgid "Activity Call Extension"
+msgstr "افزونه تماس فعالیت"
+
+msgid "Activity Call Extensions"
+msgstr "افزونه‌های تماس فعالیت"
+
+msgid "activity call extension"
+msgstr "افزونه تماس فعالیت"
+
+#, python-format
+msgid "Successfully deleted the %(model)s and all its related records."
+msgstr "%(model)s و همه رکوردهای مرتبط آن با موفقیت حذف شد."


### PR DESCRIPTION
## Summary

Persian UI strings that concatenate English fragments with a model name come out grammatically wrong (missing verb, mixed EN/FA). This interpolates the model name into one translatable sentence, fills a few empty `fa` catalogs, and fixes a delete crash.

**Note on file count:** most of the diff is not new logic. The same 1-line empty-state and delete-copy change is repeated across list/card/kanban/chart/split/timeline templates, plus catalog entries in previously empty `calls`, `approvals`, and `reviews` `.po` files (lots of msgstr fills, same msgids). Review the Python and a couple of templates; the rest is mechanical.

- Interpolate model names in empty-state and delete messages so Persian word order is correct
- Stop using `.title()` on permission `verbose_name` (it broke msgid matching) and wrap labels with `{% trans %}`
- Fill Persian catalogs for Calls / Approvals / Reviews model names
- Fix `'dict' object is not callable` on delete confirm: `delete()` rebound `_` to `{}`, then called `_("...")`

## Test plan
- [ ] Roles and Permissions: section/model names render in Persian (Call Log, Approval process, etc.)
- [ ] Empty list/card/kanban: full sentence, e.g. «هنوز چیزی برای نمایش وجود ندارد. لطفاً سرنخ‌ها را اضافه کنید.»
- [ ] Delete a record with relations (e.g. Big Deal Alerts): confirm succeeds; toast interpolates the model name in Persian
- [ ] Delete without relations still works (hard and soft)