### PR TITLE
[ADD] DOCKER: Publish official multi-arch images to Docker Hub

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,269 @@
+# Build and publish the official Horilla CRM image to Docker Hub.
+#
+# docker-ci.yml is the PR gate and stays untouched; this is the release path.
+# It smoke-tests the built image before any push, so a broken image cannot be
+# published even if the build itself succeeds.
+#
+# Tag policy is driven entirely by whether the git tag has a pre-release suffix:
+#   1.13.7      -> 1.13.7, 1.13, latest  + mirror to the deprecated horilla/crm
+#   1.13.7-rc1  -> 1.13.7-rc1 only       (no latest, no minor alias, no mirror)
+# A pre-release must never take `latest` -- that is the one mistake here that
+# would reach users, so it is asserted after push and testable via dry_run.
+
+name: Docker Publish
+
+on:
+  push:
+    tags:
+      - "[0-9]+.[0-9]+.[0-9]+"
+      - "[0-9]+.[0-9]+.[0-9]+-*"
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to build (e.g. 1.13.7). Required for dispatch."
+        required: true
+      dry_run:
+        description: "Build and smoke-test, but do not push"
+        type: boolean
+        default: true
+
+env:
+  IMAGE: horilla/horilla-crm
+  LEGACY_IMAGE: horilla/crm
+  PLATFORMS: linux/amd64,linux/arm64
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Resolve version and release channel
+        id: v
+        run: |
+          set -euo pipefail
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            VERSION="${{ inputs.version }}"
+            DRY_RUN="${{ inputs.dry_run }}"
+          else
+            VERSION="${GITHUB_REF#refs/tags/}"
+            DRY_RUN="false"
+          fi
+
+          # A '-' anywhere after the patch number means pre-release (rc, beta,
+          # alpha). Shell pattern match rather than grep: this decides whether
+          # the build may take :latest, so it should not depend on which grep
+          # implementation is on PATH.
+          case "$VERSION" in
+            *-*) PRERELEASE=true ;;
+            *)   PRERELEASE=false ;;
+          esac
+
+          echo "version=$VERSION"       >> "$GITHUB_OUTPUT"
+          echo "prerelease=$PRERELEASE" >> "$GITHUB_OUTPUT"
+          echo "dry_run=$DRY_RUN"       >> "$GITHUB_OUTPUT"
+          # Real build time. repository.updated_at is the repo's metadata mtime
+          # and is empty on workflow_dispatch, which would ship a blank label.
+          echo "build_date=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_OUTPUT"
+          echo "Version=$VERSION prerelease=$PRERELEASE dry_run=$DRY_RUN"
+
+      - name: Assert __version__ matches the tag
+        run: |
+          set -euo pipefail
+          # The image label must not disagree with the tag it ships under.
+          # A pre-release builds the same code as its base version, so
+          # 1.13.7-rc1 legitimately carries __version__ == "1.13.7".
+          #
+          # Note the import form: in this repo `horilla.__version__` is the
+          # *module*, not the string (horilla/__init__.py does not re-export
+          # it), so the value has to come from inside that module.
+          MOD=$(python3 -c 'from horilla.__version__ import __version__; print(__version__)')
+          BASE="${{ steps.v.outputs.version }}"
+          BASE="${BASE%%-*}"
+          if [ "$MOD" != "$BASE" ]; then
+            echo "::error::horilla/__version__.py is '$MOD' but the tag resolves to '$BASE'."
+            echo "Update horilla/__version__.py, or tag the version it already declares."
+            exit 1
+          fi
+          echo "Version check OK: __version__=$MOD, tag base=$BASE"
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      # ---- Smoke test before any push. Single-arch (native amd64) is enough to
+      # prove the image boots; the multi-arch build reuses the same layers. ----
+
+      - name: Build amd64 image for smoke test
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          load: true
+          push: false
+          platforms: linux/amd64
+          tags: horilla-crm:smoketest
+          build-args: |
+            VERSION=${{ steps.v.outputs.version }}
+            VCS_REF=${{ github.sha }}
+            BUILD_DATE=${{ steps.v.outputs.build_date }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Smoke test — version, migrations, health, readiness
+        run: |
+          set -euo pipefail
+
+          # --entrypoint is required: the image's ENTRYPOINT is entrypoint.sh,
+          # which blocks waiting for Postgres long before it would exec this
+          # command. Overriding CMD alone is not enough.
+          IMG_VERSION=$(docker run --rm --entrypoint python horilla-crm:smoketest \
+            -c "from horilla.__version__ import __version__; print(__version__)")
+          echo "Image reports __version__=$IMG_VERSION"
+
+          docker network create horilla-smoke
+
+          # The container MUST be named "db": entrypoint.sh hardcodes
+          # `nc -z db 5432` with no DB_HOST override, so any other name makes
+          # the wait loop fail regardless of what DATABASE_URL says.
+          docker run -d --name db --network horilla-smoke \
+            -e POSTGRES_DB=horilla_db -e POSTGRES_USER=horilla_user \
+            -e POSTGRES_PASSWORD=horilla_pass postgres:16-alpine
+
+          # CRM uses Channels/Celery and reads REDIS_URL at startup.
+          docker run -d --name redis --network horilla-smoke \
+            redis:7-alpine redis-server --requirepass horilla_pass
+
+          for i in $(seq 1 60); do
+            docker exec db pg_isready -U horilla_user -d horilla_db >/dev/null 2>&1 && break
+            sleep 2
+            [ "$i" -eq 60 ] && { echo "::error::Postgres never became ready"; exit 1; }
+          done
+
+          docker run -d --name smoke-web --network horilla-smoke -p 8000:8000 \
+            -e DEBUG=0 \
+            -e SECRET_KEY=ci-smoke-test-key-not-a-real-secret-000000000000 \
+            -e ALLOWED_HOSTS=localhost,127.0.0.1 \
+            -e CSRF_TRUSTED_ORIGINS=http://localhost:8000 \
+            -e DATABASE_URL=postgres://horilla_user:horilla_pass@db:5432/horilla_db \
+            -e REDIS_URL=redis://:horilla_pass@redis:6379/0 \
+            -e CELERY_BROKER_URL=redis://:horilla_pass@redis:6379/0 \
+            -e CELERY_RESULT_BACKEND=redis://:horilla_pass@redis:6379/0 \
+            horilla-crm:smoketest
+
+          # Generous budget: the entrypoint runs the full migration set against
+          # an empty database before uvicorn binds. The HR image needed ~212s
+          # for the same shape of work, so a tight bound reads as a health
+          # failure for an image that is actually fine.
+          echo "Waiting for /health/ (migrations run first, this takes minutes) ..."
+          for i in $(seq 1 300); do
+            if curl -sf --max-time 5 http://localhost:8000/health/ | grep -q '"status"'; then
+              echo "Health OK after ~$((i * 2))s"; break
+            fi
+            # Fail fast if the container exited: waiting out the full budget for
+            # a dead container hides the real error behind a timeout.
+            if [ "$(docker inspect -f '{{.State.Status}}' smoke-web 2>/dev/null)" != "running" ]; then
+              echo "::error::Container exited during startup"
+              docker logs --tail=100 smoke-web; exit 1
+            fi
+            # Progress every 30s so a stall is distinguishable from slow work.
+            if [ $((i % 15)) -eq 0 ]; then
+              echo "  ... still waiting ($((i * 2))s): $(docker logs --tail=1 smoke-web 2>&1 | tail -1)"
+            fi
+            sleep 2
+            if [ "$i" -eq 300 ]; then
+              echo "::error::Health check failed after 600s"
+              docker logs --tail=100 smoke-web; exit 1
+            fi
+          done
+
+      - name: Tear down smoke stack
+        if: always()
+        run: |
+          docker rm -f smoke-web db redis 2>/dev/null || true
+          docker network rm horilla-smoke 2>/dev/null || true
+
+      - name: Scan image (fail on CRITICAL)
+        uses: aquasecurity/trivy-action@v0.36.0
+        with:
+          image-ref: horilla-crm:smoketest
+          severity: CRITICAL
+          exit-code: "1"
+          ignore-unfixed: true
+
+      # ---- Publish. Everything below is skipped on a dry run. ----
+
+      - name: Log in to Docker Hub
+        if: steps.v.outputs.dry_run != 'true'
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Compute tags
+        id: tags
+        run: |
+          set -euo pipefail
+          V="${{ steps.v.outputs.version }}"
+          if [ "${{ steps.v.outputs.prerelease }}" = "true" ]; then
+            # Pre-release: the exact version and nothing else. No latest, no
+            # minor alias, and never the deprecated mirror.
+            TAGS="${IMAGE}:${V}"
+          else
+            MINOR="${V%.*}"
+            TAGS="${IMAGE}:${V},${IMAGE}:${MINOR},${IMAGE}:latest"
+            TAGS="${TAGS},${LEGACY_IMAGE}:${V},${LEGACY_IMAGE}:${MINOR},${LEGACY_IMAGE}:latest"
+          fi
+          echo "tags=$TAGS" >> "$GITHUB_OUTPUT"
+          {
+            echo "### Docker publish"
+            echo ""
+            echo "- version: \`$V\`"
+            echo "- pre-release: \`${{ steps.v.outputs.prerelease }}\`"
+            echo "- dry run: \`${{ steps.v.outputs.dry_run }}\`"
+            echo "- platforms: \`${PLATFORMS}\`"
+            echo ""
+            echo "Tags:"
+            printf '%s\n' "$TAGS" | tr ',' '\n' | sed 's/^/- `/;s/$/`/'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Build and push multi-arch
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: ${{ env.PLATFORMS }}
+          push: ${{ steps.v.outputs.dry_run != 'true' }}
+          tags: ${{ steps.tags.outputs.tags }}
+          build-args: |
+            VERSION=${{ steps.v.outputs.version }}
+            VCS_REF=${{ github.sha }}
+            BUILD_DATE=${{ steps.v.outputs.build_date }}
+          provenance: true
+          sbom: true
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Verify published manifest
+        if: steps.v.outputs.dry_run != 'true'
+        run: |
+          set -euo pipefail
+          V="${{ steps.v.outputs.version }}"
+          docker buildx imagetools inspect "${IMAGE}:${V}"
+
+          # A pre-release must not have moved `latest`. If this fires, the tag
+          # policy above regressed and users would be pulling an RC by default.
+          if [ "${{ steps.v.outputs.prerelease }}" = "true" ]; then
+            PUBLISHED=$(docker buildx imagetools inspect "${IMAGE}:${V}" \
+              --format '{{json .Manifest.Digest}}' 2>/dev/null || echo '""')
+            LATEST=$(docker buildx imagetools inspect "${IMAGE}:latest" \
+              --format '{{json .Manifest.Digest}}' 2>/dev/null || echo '""')
+            if [ "$LATEST" != '""' ] && [ "$PUBLISHED" = "$LATEST" ]; then
+              echo "::error::Pre-release $V is being served as :latest. Tag policy regressed."
+              exit 1
+            fi
+            echo "Confirmed: pre-release did not take :latest"
+          fi

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,8 +19,10 @@ ENV PATH="/opt/venv/bin:$PATH"
 
 # Install Python dependencies
 COPY requirements.txt .
+# psycopg2-binary is pinned in requirements.txt -- repeating it here unpinned
+# silently overrides that pin. uvicorn is not in requirements.txt, so it stays.
 RUN pip install --upgrade "pip>=26.0" \
-    && pip install --no-cache-dir -r requirements.txt uvicorn[standard] psycopg2-binary
+    && pip install --no-cache-dir -r requirements.txt uvicorn[standard]
 
 # Production stage - minimal runtime image
 FROM python:3.13-slim AS production
@@ -55,11 +57,28 @@ COPY --chown=appuser:appuser . .
 COPY --chown=appuser:appuser docker/entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
 
-# Create necessary directories and set permissions
+# The COPYs above already set --chown, so only the new dirs need ownership;
+# a recursive chown over /app would duplicate a whole layer for no gain.
 RUN mkdir -p staticfiles media \
-    && chown -R appuser:appuser /app
+    && chown appuser:appuser staticfiles media
 
 USER appuser
+
+# Build metadata. VERSION should match horilla/__version__.py and the release
+# tag; the publish workflow passes all three and fails if they disagree.
+ARG VERSION=dev
+ARG VCS_REF=unknown
+ARG BUILD_DATE=unknown
+LABEL org.opencontainers.image.title="Horilla CRM" \
+      org.opencontainers.image.description="Free and open source CRM software" \
+      org.opencontainers.image.version="${VERSION}" \
+      org.opencontainers.image.revision="${VCS_REF}" \
+      org.opencontainers.image.created="${BUILD_DATE}" \
+      org.opencontainers.image.source="https://github.com/horilla/horilla-crm" \
+      org.opencontainers.image.url="https://www.horilla.com" \
+      org.opencontainers.image.documentation="https://docs.horilla.com" \
+      org.opencontainers.image.vendor="Horilla" \
+      org.opencontainers.image.licenses="LGPL-2.1"
 
 EXPOSE 8000
 


### PR DESCRIPTION
CRM images are published by hand today -- docker-ci.yml builds and smoke-tests but never pushes, so horilla/crm was tagged manually with no scan and no reproducible pipeline. This adds the release path, mirroring what now runs for Horilla HR.

.github/workflows/docker-publish.yml builds horilla/horilla-crm for linux/amd64 and linux/arm64 on a semver tag. docker-ci.yml is untouched; it stays the PR gate. The release path smoke-tests the built image -- boots it against Postgres and Redis and waits on /health/ -- before any push, so a build that succeeds but does not run cannot be published. Trivy fails the release on CRITICAL findings.

Tag policy keys off a pre-release suffix:

  1.13.7      -> 1.13.7, 1.13, latest, and the same three mirrored to the
                 deprecated horilla/crm so no existing pull breaks
  1.13.7-rc1  -> 1.13.7-rc1 alone: no latest, no minor alias, no mirror

Four things differ from the HR pipeline and are not copy-paste:

- The version check imports `from horilla.__version__ import __version__`. Unlike HR, horilla/__init__.py here does not re-export the string, so `horilla.__version__` is the module and HR's one-liner would print a repr.
- The Postgres container must be named exactly "db". entrypoint.sh hardcodes `nc -z db 5432` with no DB_HOST override, so any other name hangs the wait loop no matter what DATABASE_URL says.
- The smoke stack also runs Redis, which CRM reads at startup for Channels and Celery.
- Pre-release detection uses a shell case statement rather than grep, since it decides whether a build may take :latest and should not depend on which grep is on PATH.

Dockerfile: added OCI labels (version, revision, source, LGPL-2.1) fed by build args. Dropped the unpinned psycopg2-binary from the pip line, which silently overrode the 2.9.12 pin in requirements.txt -- uvicorn stays, it is genuinely not in requirements.txt. Replaced a recursive chown over /app with one on the two new directories, since the COPYs already set --chown.