### PR TITLE
fix: apply LANGUAGE_BIDI RTL to web-to-lead public and builder forms

### DIFF
--- a/horilla/contrib/core/tests.py
+++ b/horilla/contrib/core/tests.py
@@ -1,1 +1,85 @@
-# Create your core tests here.
+"""Tests for Horilla core RTL assets and web-to-lead field parsing."""
+
+from pathlib import Path
+
+from django.conf import settings
+from django.template.loader import render_to_string
+from django.test import SimpleTestCase
+
+from horilla_crm.leads.views.web_to_lead import (
+    parse_selected_fields,
+    render_form_preview,
+)
+
+
+class ParseSelectedFieldsTests(SimpleTestCase):
+    """Edit Form must not 500 when selected_fields is empty or invalid JSON."""
+
+    def test_empty_and_invalid_values_become_an_empty_list(self):
+        self.assertEqual(parse_selected_fields(""), [])
+        self.assertEqual(parse_selected_fields(None), [])
+        self.assertEqual(parse_selected_fields("   "), [])
+        self.assertEqual(parse_selected_fields("not-json"), [])
+        self.assertEqual(parse_selected_fields("{}"), [])
+
+    def test_valid_json_list_is_returned(self):
+        self.assertEqual(
+            parse_selected_fields('["first_name", "email"]'),
+            ["first_name", "email"],
+        )
+
+
+class WebToLeadRtlTemplateTests(SimpleTestCase):
+    """Standalone public form follows the same LANGUAGE_BIDI dir pattern as login."""
+
+    def test_public_form_template_uses_language_bidi_dir(self):
+        path = (
+            Path(settings.BASE_DIR)
+            / "horilla_crm"
+            / "leads"
+            / "templates"
+            / "web_to_lead"
+            / "public_lead_form.html"
+        )
+        text = path.read_text(encoding="utf-8")
+        self.assertIn(
+            'dir="{% if LANGUAGE_BIDI %}rtl{% else %}ltr{% endif %}"', text
+        )
+        self.assertIn("inject_html/rtl_assets.html", text)
+
+    def test_form_preview_sets_dir_from_language_bidi(self):
+        html = render_to_string(
+            "web_to_lead/form_preview.html",
+            {"fields": [], "form_name": "Contact Us", "LANGUAGE_BIDI": True},
+        )
+        self.assertIn('dir="rtl"', html)
+
+    def test_edit_preview_uses_form_language_direction(self):
+        html = render_form_preview([], "Contact Us", "", "fa")
+        self.assertIn('dir="rtl"', html)
+        html = render_form_preview([], "Contact Us", "", "en")
+        self.assertIn('dir="ltr"', html)
+
+    def test_edit_form_button_has_persian_translation(self):
+        po = (
+            Path(settings.BASE_DIR)
+            / "horilla_crm"
+            / "leads"
+            / "locale"
+            / "fa"
+            / "LC_MESSAGES"
+            / "django.po"
+        )
+        text = po.read_text(encoding="utf-8")
+        self.assertIn('msgid "Edit Form"', text)
+        self.assertIn('msgstr "ویرایش فرم"', text)
+
+
+class WebToLeadRtlCssTests(SimpleTestCase):
+    """Form preview and public-form labels are aligned in rtl.css."""
+
+    def test_form_preview_rtl_rules_are_in_rtl_css(self):
+        css_path = Path(settings.BASE_DIR) / "static" / "assets" / "css" / "rtl.css"
+        css = css_path.read_text(encoding="utf-8")
+        self.assertIn('[dir="rtl"] #formPreview label', css)
+        self.assertIn('[dir="rtl"] .form-label', css)

--- a/horilla_crm/leads/locale/fa/LC_MESSAGES/django.po
+++ b/horilla_crm/leads/locale/fa/LC_MESSAGES/django.po
@@ -624,6 +624,9 @@ msgstr "ساخت فرم وب برای دریافت مستقیم سرنخ از و
 msgid "Form Builder"
 msgstr "سازنده فرم"
 
+msgid "Edit Form"
+msgstr "ویرایش فرم"
+
 msgid "Enter form name"
 msgstr "نام فرم را وارد کنید"
 

--- a/horilla_crm/leads/templates/web_to_lead/form_preview.html
+++ b/horilla_crm/leads/templates/web_to_lead/form_preview.html
@@ -1,3 +1,4 @@
+<div dir="{% if LANGUAGE_BIDI %}rtl{% else %}ltr{% endif %}">
 {% if not color %}
     <h3
         id="formHeading"
@@ -92,3 +93,4 @@
         {% trans "Select fields to preview form" %}
     </p>
 {% endif %}
+</div>

--- a/horilla_crm/leads/templates/web_to_lead/lead_form_builder.html
+++ b/horilla_crm/leads/templates/web_to_lead/lead_form_builder.html
@@ -314,7 +314,9 @@
                 <!-- RIGHT COLUMN: Preview -->
                 <div class="col-span-6">
                     <div id="formPreview" class="p-5 border border-dark-50 rounded-md sticky top-0">
-                        {% if preview_fields %}
+                        {% if preview_html %}
+                            {{ preview_html }}
+                        {% elif preview_fields %}
                             {% include "web_to_lead/form_preview.html" with fields=preview_fields form_name=form_data.form_name color=form_data.color %}
                         {% else %}
                             <h3

--- a/horilla_crm/leads/templates/web_to_lead/public_lead_form.html
+++ b/horilla_crm/leads/templates/web_to_lead/public_lead_form.html
@@ -1,5 +1,8 @@
 <!DOCTYPE html>
-<html lang="{{ form_obj.language|default:'en' }}">
+<html
+    lang="{{ form_obj.language|default:'en' }}"
+    dir="{% if LANGUAGE_BIDI %}rtl{% else %}ltr{% endif %}"
+>
     <head>
         <meta charset="UTF-8">
         <title>{{ form_obj.form_name|default:'Contact Form' }}</title>
@@ -31,6 +34,7 @@
                 margin-bottom: 5px;
                 color: #444;
                 font-size: 13px;
+                text-align: start;
             }
             .form-input {
                 width: 100%;
@@ -40,6 +44,7 @@
                 border-radius: 6px;
                 color: #444;
                 font-size: 14px;
+                text-align: start;
             }
             .form-input:hover,
             .form-input:focus {
@@ -133,6 +138,7 @@
                 background-color: var(--form-color-light, rgba(237, 79, 56, 0.15)) !important;
             }
         </style>
+        {% include "inject_html/rtl_assets.html" %}
     </head>
     <body>
         {% with header_color=form_obj.header_color|default:"#ed4f38" %}
@@ -300,7 +306,8 @@
 
                 $('.js-example-basic-single').select2({
                     allowClear: true,
-                    placeholder: "Select an option"
+                    placeholder: "Select an option",
+                    dir: document.documentElement.getAttribute("dir") || "ltr"
                 });
 
                 // Apply custom styles to dropdown with both light background and colored text

--- a/horilla_crm/leads/views/web_to_lead.py
+++ b/horilla_crm/leads/views/web_to_lead.py
@@ -9,6 +9,7 @@ from django import forms
 from django.contrib.auth.mixins import LoginRequiredMixin
 from django.template.loader import render_to_string
 from django.utils import translation
+from django.utils.safestring import mark_safe
 from django.views import View
 from django.views.decorators.clickjacking import xframe_options_exempt
 from django.views.decorators.csrf import csrf_exempt
@@ -28,6 +29,36 @@ from horilla.web import HttpNotFound, HttpResponse, RedirectResponse
 
 # Local imports
 from horilla_crm.leads.models import Lead, LeadCaptureForm, LeadStatus
+
+
+def parse_selected_fields(raw):
+    """Return the stored field-name list, or [] if missing or invalid JSON."""
+    if raw is None:
+        return []
+    if isinstance(raw, list):
+        return raw
+    text = str(raw).strip()
+    if not text:
+        return []
+    try:
+        data = json.loads(text)
+    except json.JSONDecodeError:
+        return []
+    return data if isinstance(data, list) else []
+
+
+def render_form_preview(fields, form_name, color, language):
+    """Render the builder preview in the form language without changing the UI locale."""
+    with translation.override(language or "en"):
+        return render_to_string(
+            "web_to_lead/form_preview.html",
+            {
+                "fields": fields,
+                "form_name": form_name,
+                "color": color,
+                "LANGUAGE_BIDI": translation.get_language_bidi(),
+            },
+        )
 
 
 def get_preview_fields_data(selected_fields):
@@ -119,7 +150,7 @@ class LeadFormBuilderView(LoginRequiredMixin, TemplateView):
             )
 
             if self.request.GET.get("edit"):
-                selected_fields = json.loads(saved_form.selected_fields)
+                selected_fields = parse_selected_fields(saved_form.selected_fields)
                 context["form_data"] = {
                     "form_name": saved_form.form_name,
                     "return_url_enable": saved_form.return_url_enable,
@@ -132,6 +163,14 @@ class LeadFormBuilderView(LoginRequiredMixin, TemplateView):
                     "lead_owner": saved_form.lead_owner_id,
                 }
                 context["preview_fields"] = get_preview_fields_data(selected_fields)
+                context["preview_html"] = mark_safe(
+                    render_form_preview(
+                        context["preview_fields"],
+                        saved_form.form_name,
+                        saved_form.header_color,
+                        saved_form.language,
+                    )
+                )
         return context
 
 
@@ -176,18 +215,10 @@ class UpdateFormPreviewView(LoginRequiredMixin, TemplateView):
         form_name = request.POST.get("form_name", "").strip()
         color = request.POST.get("color")
         language = request.POST.get("language", "en")
-        translation.activate(language)
-
         fields_data = get_preview_fields_data(selected_fields)
-
-        context = {
-            "fields": fields_data,
-            "color": color,
-            "form_name": form_name,
-            "language": language,
-        }
-
-        return render(request, self.template_name, context)
+        return HttpResponse(
+            render_form_preview(fields_data, form_name, color, language)
+        )
 
 
 @method_decorator(htmx_required, name="dispatch")
@@ -321,6 +352,7 @@ class SaveLeadFormView(LoginRequiredMixin, FormView):
                 "form_obj": self.object,
                 "selected_fields_parsed": parsed_fields,
                 "form_id": self.object.id,
+                "LANGUAGE_BIDI": translation.get_language_bidi(),
                 "view": {"kwargs": {"form_id": self.object.id}},
             },
         )
@@ -370,12 +402,22 @@ class SaveLeadFormView(LoginRequiredMixin, FormView):
                 "lead_owner": self.request.POST.get("lead_owner"),
             }
 
+            preview_fields = get_preview_fields_data(form_data["selected_fields"])
             context = {
                 "form": form,
                 "errors": form.errors,
                 "lead_fields": lead_fields,
                 "form_data": form_data,
                 "lead_owners": User.objects.filter(is_active=True),
+                "preview_fields": preview_fields,
+                "preview_html": mark_safe(
+                    render_form_preview(
+                        preview_fields,
+                        form_data["form_name"],
+                        form_data["color"],
+                        form_data["language"],
+                    )
+                ),
             }
 
             response = render(self.request, self.template_name, context)
@@ -447,7 +489,7 @@ class PublicLeadFormView(CreateView):
             # Activate the form's language
             translation.activate(form_config.language)
 
-            selected_fields = json.loads(form_config.selected_fields)
+            selected_fields = parse_selected_fields(form_config.selected_fields)
 
             class DynamicLeadForm(forms.ModelForm):
                 """Dynamically generated form based on selected fields."""
@@ -479,7 +521,7 @@ class PublicLeadFormView(CreateView):
             context["form_config"] = form_config
 
             # Parse selected fields for template
-            selected_fields = json.loads(form_config.selected_fields)
+            selected_fields = parse_selected_fields(form_config.selected_fields)
             parsed_fields = []
 
             for field_name in selected_fields:

--- a/static/assets/css/rtl.css
+++ b/static/assets/css/rtl.css
@@ -484,3 +484,47 @@ html[dir="rtl"] .horilla-dashboard-sortable.is-edit-sortable>[data-id] {
 [dir="rtl"] .genealogy-tree .member-footer div.downline {
   justify-content: center;
 }
+
+/*
+ * Web-to-lead form maker preview. The preview fragment sets dir from
+ * LANGUAGE_BIDI (form language on HTMX refresh; UI language on first paint).
+ */
+[dir="rtl"] #formPreview label,
+#formPreview [dir="rtl"] label,
+[dir="rtl"] #formPreview input,
+#formPreview [dir="rtl"] input,
+[dir="rtl"] #formPreview textarea,
+#formPreview [dir="rtl"] textarea,
+[dir="rtl"] #formPreview select,
+#formPreview [dir="rtl"] select {
+  text-align: right;
+}
+
+[dir="rtl"] #formPreview input,
+#formPreview [dir="rtl"] input,
+[dir="rtl"] #formPreview textarea,
+#formPreview [dir="rtl"] textarea {
+  direction: rtl;
+}
+
+#formPreview [dir="ltr"] label,
+#formPreview [dir="ltr"] input,
+#formPreview [dir="ltr"] textarea,
+#formPreview [dir="ltr"] select {
+  text-align: left;
+}
+
+#formPreview [dir="ltr"] input,
+#formPreview [dir="ltr"] textarea {
+  direction: ltr;
+}
+
+/* Public web-to-lead form (standalone page; html[dir] from LANGUAGE_BIDI) */
+[dir="rtl"] .form-label {
+  text-align: right;
+}
+
+[dir="rtl"] .form-input {
+  text-align: right;
+  direction: rtl;
+}


### PR DESCRIPTION
## Summary
- Public web-to-lead forms and the form-maker preview now set `dir` from `LANGUAGE_BIDI` and load `inject_html/rtl_assets.html`, matching login/error.
- Label/input alignment for the preview and public form lives in `rtl.css`; the builder preview is rendered in the form language without switching the settings UI locale.
- Edit Form no longer 500s when `selected_fields` is empty or invalid, and the button is translated in Persian.

## Test plan
- [ ] Open a Persian (or other RTL) web-to-lead form in a new tab and confirm labels/inputs are right-aligned and Vazirmatn loads.
- [ ] Open the same form in English and confirm it stays LTR.
- [ ] In settings, open the form maker, click Edit Form, and confirm the preview matches the form language (RTL when the form language is RTL).
- [ ] Change the language dropdown and confirm the preview updates without flipping the rest of settings.
- [ ] Click Generate, then Preview the public URL, and confirm stored HTML is RTL when the form language is RTL.
- [ ] Edit a form with empty `selected_fields` and confirm it opens instead of 500ing.