### PR TITLE
fix: History tab RTL, Shamsi dates, expand view, and filter modal

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ RUN apt-get update \
         libpq-dev \
         libjpeg-dev \
         zlib1g-dev \
+        gettext \
     && rm -rf /var/lib/apt/lists/*
 
 # Create virtual environment
@@ -39,6 +40,7 @@ RUN apt-get update \
         zlib1g \
         curl \
         netcat-openbsd \
+        gettext \
     && rm -rf /var/lib/apt/lists/* \
     && apt-get clean
 

--- a/horilla_crm/leads/locale/fa/LC_MESSAGES/django.po
+++ b/horilla_crm/leads/locale/fa/LC_MESSAGES/django.po
@@ -746,3 +746,72 @@ msgstr "مرحله نهایی با موفقیت تغییر یافت."
 
 msgid "Automatically create leads from incoming emails."
 msgstr "ایجاد خودکار سرنخ از ایمیل‌های دریافتی."
+
+msgid "by"
+msgstr "توسط"
+
+#, python-format
+msgid "New %(model)s created"
+msgstr "%(model)s جدید ایجاد شد"
+
+#, python-format
+msgid "%(counter)s event"
+msgid_plural "%(counter)s events"
+msgstr[0] "%(counter)s رویداد"
+msgstr[1] "%(counter)s رویداد"
+
+msgid "Created"
+msgstr "ایجاد شد"
+
+msgid "edit"
+msgstr "ویرایش"
+
+msgid "edits"
+msgstr "ویرایش"
+
+msgid "event"
+msgstr "رویداد"
+
+msgid "events"
+msgstr "رویداد"
+
+#, python-format
+msgid "%(type)s added"
+msgstr "%(type)s اضافه شد"
+
+msgid "Added"
+msgstr "افزوده شد"
+
+msgid "Removed"
+msgstr "حذف شد"
+
+msgid "Url"
+msgstr "نشانی"
+
+msgid "URL"
+msgstr "نشانی"
+
+msgid "Sender"
+msgstr "فرستنده"
+
+msgid "Message"
+msgstr "پیام"
+
+msgid "Expand"
+msgstr "بزرگ‌نمایی"
+
+msgid "Collapse"
+msgstr "کوچک‌نمایی"
+
+msgid "Select date to filter"
+msgstr "تاریخ را برای فیلتر انتخاب کنید"
+
+msgid "Filter date"
+msgstr "تاریخ فیلتر"
+
+msgid "Apply"
+msgstr "اعمال"
+
+msgid "Clear Filters"
+msgstr "پاک کردن فیلترها"
+

--- a/horilla_crm/leads/templatetags/history_i18n.py
+++ b/horilla_crm/leads/templatetags/history_i18n.py
@@ -1,0 +1,185 @@
+"""History tab datetime display (Shamsi when the UI language is Persian)."""
+
+from datetime import date, datetime
+
+from django import template
+from django.utils.translation import get_language
+
+from horilla.contrib.generics.templatetags.horilla_tags._shared import (
+    _get_request_user_company,
+    format_datetime_value,
+)
+from horilla.extension.formatting import get_datetime_formatter
+
+register = template.Library()
+
+
+def _format_shamsi(value, *, user=None, company=None, convert_timezone=True):
+    """Timezone-adjust then format with the Jalali calendar."""
+    formatter = get_datetime_formatter()
+    try:
+        from horilla_jalali.calendar import format_gregorian_as_jalali
+    except Exception:
+        format_gregorian_as_jalali = None
+
+    if isinstance(value, datetime):
+        if convert_timezone:
+            value = formatter._apply_timezone(
+                value, user=user, company=company, convert_timezone=True
+            )
+        fmt = formatter._resolve_datetime_format(user=user, company=company)
+        try:
+            from horilla_jalali.calendar import to_24h_strftime
+
+            fmt = to_24h_strftime(fmt)
+        except Exception:
+            fmt = (
+                fmt.replace("%-I", "%-H")
+                .replace("%I", "%H")
+                .replace(" %p", "")
+                .replace(" %P", "")
+                .replace("%p", "")
+                .replace("%P", "")
+                .replace("%S", "")
+                .replace("%f", "")
+            ).strip().rstrip(":")
+    elif isinstance(value, date):
+        fmt = formatter._resolve_date_format(user=user, company=company)
+    else:
+        return None
+
+    if format_gregorian_as_jalali is not None:
+        try:
+            return format_gregorian_as_jalali(value, fmt)
+        except Exception:
+            pass
+
+    import jdatetime
+
+    if isinstance(value, datetime):
+        jalali_value = jdatetime.datetime.fromgregorian(
+            datetime=value, locale=jdatetime.FA_LOCALE
+        )
+    else:
+        jalali_value = jdatetime.date.fromgregorian(
+            date=value, locale=jdatetime.FA_LOCALE
+        )
+    formatted = jalali_value.strftime(fmt.replace("%b", "%B"))
+    try:
+        from horilla_jalali.calendar import to_persian_datetime_digits
+
+        return to_persian_datetime_digits(formatted)
+    except Exception:
+        return formatted
+
+
+def _parse_datetime_string(value):
+    if not isinstance(value, str) or value in ("", "--", "None", "none"):
+        return None
+    try:
+        from horilla_jalali.calendar import parse_localized_gregorian_display
+
+        localized = parse_localized_gregorian_display(value)
+        if localized is not None:
+            return localized
+    except Exception:
+        pass
+    try:
+        from dateutil import parser as dateutil_parser
+    except Exception:
+        return None
+    try:
+        return dateutil_parser.parse(value)
+    except (ValueError, TypeError, OverflowError):
+        return None
+
+
+_DATE_LIKE_FIELD_TYPES = ("DateTimeField", "DateField", "TimeField")
+_DATE_LABEL_HINTS = (
+    "تاریخ",
+    "start date",
+    "end date",
+    "due date",
+    "updated at",
+    "created at",
+    "به‌روزرسانی شده در",
+    "ایجاد شده در",
+)
+
+
+@register.filter
+def history_is_date_field(entry, field_label):
+    """True for date/datetime fields, including translated History labels."""
+    try:
+        from horilla.contrib.generics.templatetags.horilla_tags.history_display import (
+            is_date_field,
+        )
+
+        if is_date_field(entry, field_label):
+            return True
+    except Exception:
+        pass
+    label = str(field_label or "").strip().lower()
+    if not label:
+        return False
+    if any(hint in label for hint in _DATE_LABEL_HINTS):
+        return True
+    try:
+        model = entry.content_type.model_class()
+    except Exception:
+        return False
+    if model is None:
+        return False
+    from django.utils.translation import gettext
+
+    for field in model._meta.get_fields():
+        if type(field).__name__ not in _DATE_LIKE_FIELD_TYPES:
+            continue
+        verbose = str(getattr(field, "verbose_name", "") or "").strip().lower()
+        name = getattr(field, "name", "").replace("_", " ").strip().lower()
+        translated = (
+            gettext(str(getattr(field, "verbose_name", "") or "")).strip().lower()
+        )
+        if label in {verbose, name, translated}:
+            return True
+    return False
+
+
+@register.filter
+def history_datetime(value):
+    """
+    Format a history timestamp. Persian UI always uses Shamsi (Jalali);
+    other languages keep the user/company datetime format.
+    """
+    _, user, company = _get_request_user_company()
+    lang = (get_language() or "").replace("_", "-").split("-")[0].lower()
+    try:
+        from horilla_jalali.calendar import uses_jalali_calendar
+
+        use_shamsi = uses_jalali_calendar(user=user)
+    except Exception:
+        use_shamsi = lang == "fa"
+
+    parsed = value
+    parsed_from_string = False
+    if not isinstance(value, (date, datetime)):
+        parsed = _parse_datetime_string(value)
+        parsed_from_string = parsed is not None
+
+    if use_shamsi and isinstance(parsed, (date, datetime)):
+        result = _format_shamsi(
+            parsed,
+            user=user,
+            company=company,
+            convert_timezone=not parsed_from_string,
+        )
+        if result:
+            return result
+
+    formatted = format_datetime_value(
+        parsed if parsed is not None else value,
+        user=user,
+        company=company,
+        convert_timezone=True,
+    )
+    return formatted if formatted is not None else value

--- a/horilla_crm/leads/test_history_rtl.py
+++ b/horilla_crm/leads/test_history_rtl.py
@@ -1,0 +1,199 @@
+"""History tab RTL / Farsi overlays — no Horilla core or rtl.css edits."""
+
+from pathlib import Path
+
+from django.conf import settings
+from django.template.loader import get_template, render_to_string
+from django.test import SimpleTestCase
+
+
+class HistoryTabRtlOverlayTests(SimpleTestCase):
+    """Project overlays and history-rtl.css, kept off rtl.css / generics core."""
+
+    def test_rtl_css_is_unchanged_by_history_rules(self):
+        css = (
+            Path(settings.BASE_DIR) / "static" / "assets" / "css" / "rtl.css"
+        ).read_text(encoding="utf-8")
+        self.assertNotIn("#history-main", css)
+        self.assertNotIn("history-rtl.css", css)
+        self.assertNotIn("history-filter-bar", css)
+
+    def test_history_rtl_css_covers_filter_and_bidi(self):
+        css = (
+            Path(settings.BASE_DIR) / "static" / "assets" / "css" / "history-rtl.css"
+        ).read_text(encoding="utf-8")
+        self.assertIn('[dir="rtl"] #history-main .history-filter-bar', css)
+        self.assertNotIn("flex-direction: row-reverse", css)
+        self.assertIn("unicode-bidi: isolate", css)
+
+    def test_history_tab_css_expands_detail_pane(self):
+        css = (
+            Path(settings.BASE_DIR) / "static" / "assets" / "css" / "history-tab.css"
+        ).read_text(encoding="utf-8")
+        self.assertIn("history-tab-expanded", css)
+        self.assertIn("#detailHeaderCard", css)
+
+    def test_rtl_assets_overlay_loads_history_stylesheet(self):
+        html = render_to_string(
+            "inject_html/rtl_assets.html", {"LANGUAGE_BIDI": True}
+        )
+        self.assertIn("assets/css/rtl.css", html)
+        self.assertIn("assets/css/history-rtl.css", html)
+
+    def test_history_tab_overlay_uses_localizable_phrases(self):
+        text = (
+            Path(settings.BASE_DIR) / "templates" / "history_tab.html"
+        ).read_text(encoding="utf-8")
+        self.assertIn("New {{ model }} created", text)
+        self.assertIn("{% trans field %}", text)
+        self.assertIn("LANGUAGE_BIDI", text)
+        self.assertIn("history-filter-bar", text)
+        self.assertIn("history-kv", text)
+        self.assertIn("history_datetime", text)
+        self.assertIn("{% load history_i18n %}", text)
+        self.assertIn("history_is_date_field", text)
+        self.assertIn("history-expand-btn", text)
+        self.assertNotIn("sticky top-4", text)
+        actor = (
+            Path(settings.BASE_DIR)
+            / "templates"
+            / "partials"
+            / "history_entry_actor.html"
+        ).read_text(encoding="utf-8")
+        self.assertIn("{% trans \"by\" %}", actor)
+
+    def test_core_history_template_is_not_modified(self):
+        text = (
+            Path(settings.BASE_DIR)
+            / "horilla"
+            / "contrib"
+            / "generics"
+            / "templates"
+            / "history_tab.html"
+        ).read_text(encoding="utf-8")
+        self.assertNotIn("history-filter-bar", text)
+        self.assertIn("{% trans \"New\" %}", text)
+
+    def test_persian_history_strings_exist(self):
+        po = (
+            Path(settings.BASE_DIR)
+            / "horilla_crm"
+            / "leads"
+            / "locale"
+            / "fa"
+            / "LC_MESSAGES"
+            / "django.po"
+        ).read_text(encoding="utf-8")
+        self.assertIn('msgid "by"', po)
+        self.assertIn('msgstr "توسط"', po)
+        self.assertIn('msgid "New %(model)s created"', po)
+        self.assertIn('msgstr "%(model)s جدید ایجاد شد"', po)
+        self.assertIn('msgid "Sender"', po)
+        self.assertIn('msgstr "فرستنده"', po)
+        self.assertIn('msgid "Expand"', po)
+        self.assertIn('msgstr "بزرگ‌نمایی"', po)
+        self.assertIn('msgid "Select date to filter"', po)
+        self.assertIn('msgstr "تاریخ را برای فیلتر انتخاب کنید"', po)
+        self.assertIn('msgid "Apply"', po)
+        self.assertIn('msgstr "اعمال"', po)
+
+    def test_history_filter_form_overlay_is_translated(self):
+        text = (
+            Path(settings.BASE_DIR)
+            / "templates"
+            / "partials"
+            / "history_filter_form.html"
+        ).read_text(encoding="utf-8")
+        self.assertIn("{% trans \"Select date to filter\" %}", text)
+        self.assertIn("{% trans \"Filter\" %}", text)
+        self.assertIn("{% trans \"Apply\" %}", text)
+        self.assertNotIn("form.filter_date.label_tag", text)
+        self.assertIn("initHorillaJalaliInputs", text)
+
+    def test_history_tab_overlay_is_the_resolved_template(self):
+        template = get_template("history_tab.html")
+        self.assertIn("templates", Path(template.origin.name).parts)
+        self.assertNotIn("contrib", Path(template.origin.name).parts)
+
+
+class HistoryDatetimeShamsiTests(SimpleTestCase):
+    """Persian UI history timestamps must render as Jalali."""
+
+    def test_persian_history_datetime_uses_shamsi_year(self):
+        from datetime import datetime
+
+        from django.utils.translation import override
+
+        from horilla_crm.leads.templatetags.history_i18n import history_datetime
+
+        with override("fa"):
+            text = str(history_datetime(datetime(2026, 8, 19, 15, 7, 13)))
+        self.assertIn("۱۴۰۵", text)
+        self.assertNotIn("1405", text)
+        self.assertNotIn("2026", text)
+        self.assertNotIn("بعد از ظهر", text)
+        self.assertNotIn("قبل از ظهر", text)
+        self.assertNotIn("PM", text)
+        self.assertNotIn("AM", text)
+        self.assertNotRegex(text, r"[0-9]:[0-9]")
+
+    def test_twelve_hour_format_renders_as_24_hour_without_ampm(self):
+        from datetime import datetime
+        from types import SimpleNamespace
+
+        from django.utils.translation import override
+
+        from horilla_crm.leads.templatetags.history_i18n import _format_shamsi
+
+        user = SimpleNamespace(
+            date_time_format="%Y-%m-%d %I:%M:%S %p",
+            time_zone=None,
+        )
+        with override("fa"):
+            text = str(
+                _format_shamsi(
+                    datetime(2026, 8, 19, 20, 1, 59), user=user, company=None
+                )
+            )
+        self.assertIn("۱۴۰۵", text)
+        self.assertIn("۲۰:۰۱", text)
+        self.assertNotIn("20:01", text)
+        self.assertNotIn("۲۰:۰۱:۵۹", text)
+        self.assertNotIn("20:01:59", text)
+        self.assertNotIn("08:01:59", text)
+        self.assertNotIn("بعد از ظهر", text)
+        self.assertNotIn("PM", text)
+
+    def test_date_only_uses_persian_digits(self):
+        from datetime import date
+
+        from django.utils.translation import override
+
+        from horilla_crm.leads.templatetags.history_i18n import history_datetime
+
+        with override("fa"):
+            text = str(history_datetime(date(2026, 8, 19)))
+        self.assertIn("۱۴۰۵", text)
+        self.assertNotIn("1405", text)
+
+    def test_localized_persian_gregorian_converts_to_shamsi(self):
+        from django.utils.translation import override
+
+        from horilla_crm.leads.templatetags.history_i18n import history_datetime
+
+        with override("fa"):
+            text = str(history_datetime("19 اوت 2026، ساعت 8:27"))
+        self.assertIn("۱۴۰۵", text)
+        self.assertNotIn("اوت", text)
+        self.assertNotIn("2026", text)
+        self.assertNotIn("ساعت", text)
+        self.assertIn("۰۸:۲۷", text)
+        self.assertNotIn("08:27", text)
+        self.assertNotIn("۰۸:۲۷:۰۰", text)
+
+    def test_history_is_date_field_matches_persian_start_date_label(self):
+        from horilla_crm.leads.templatetags.history_i18n import history_is_date_field
+
+        self.assertTrue(history_is_date_field(None, "تاریخ شروع"))
+        self.assertTrue(history_is_date_field(None, "به‌روزرسانی شده در"))
+        self.assertFalse(history_is_date_field(None, "وضعیت"))

--- a/horilla_jalali/calendar.py
+++ b/horilla_jalali/calendar.py
@@ -77,6 +77,76 @@ def _first_directive_index(fmt: str, chars: str) -> int | None:
     return None
 
 
+_AMPM_TEXT = re.compile(
+    r"\s*(?:قبل از ظهر|بعد از ظهر|ق\.?\s*ظ|ب\.?\s*ظ|A\.?M\.?|P\.?M\.?)\s*$",
+    re.IGNORECASE,
+)
+
+_PERSIAN_DIGITS = str.maketrans("0123456789", "۰۱۲۳۴۵۶۷۸۹")
+_ASCII_DIGITS = str.maketrans("۰۱۲۳۴۵۶۷۸۹٠١٢٣٤٥٦٧٨٩", "01234567890123456789")
+
+
+def to_persian_digits(text: str) -> str:
+    """Map ASCII digits to Persian (fa) digits."""
+    if not text:
+        return text
+    return text.translate(_PERSIAN_DIGITS)
+
+
+def to_ascii_digits(text: str) -> str:
+    """Map Persian / Arabic-Indic digits to ASCII so parsers still work."""
+    if not text:
+        return text
+    return text.translate(_ASCII_DIGITS)
+
+
+def to_persian_date_digits(text: str) -> str:
+    """Map every digit in a Shamsi date/time string to Persian digits."""
+    return to_persian_digits(text)
+
+
+_SECONDS_TAIL = re.compile(r"(\d{1,2}:\d{2}):\d{2}(?:\.\d+)?")
+
+
+def drop_seconds_strftime(fmt: str) -> str:
+    """``%H:%M:%S`` → ``%H:%M`` (History Shamsi times have no seconds)."""
+    if not fmt:
+        return fmt
+    out = re.sub(r"%[-]?[Sf]", "", fmt)
+    out = re.sub(r"[:.]+(?=\s|$)", "", out)
+    return re.sub(r"\s+", " ", out).strip()
+
+
+def to_persian_datetime_digits(text: str) -> str:
+    """Persian digits for the whole datetime; drop seconds from HH:MM:SS."""
+    if not text:
+        return text
+    prefix = suffix = ""
+    inner = text
+    if inner.startswith("\u2066") and inner.endswith("\u2069"):
+        prefix, suffix = "\u2066", "\u2069"
+        inner = inner[1:-1]
+    inner = strip_ampm_suffix(to_ascii_digits(inner))
+    inner = _SECONDS_TAIL.sub(r"\1", inner)
+    return f"{prefix}{to_persian_digits(inner)}{suffix}"
+
+
+def to_24h_strftime(fmt: str) -> str:
+    """Use 24-hour time and drop AM/PM (``%p`` → بعد از ظهر / قبل از ظهر)."""
+    if not fmt:
+        return fmt
+    out = fmt.replace("%-I", "%-H").replace("%I", "%H")
+    out = re.sub(r"\s*%-?[pP]", "", out)
+    return drop_seconds_strftime(out.strip())
+
+
+def strip_ampm_suffix(text: str) -> str:
+    """Remove trailing AM/PM labels from an already-formatted datetime."""
+    if not text:
+        return text
+    return _AMPM_TEXT.sub("", text).rstrip()
+
+
 def jalali_strftime_format(fmt: str) -> str:
     """
     Adapt a Gregorian ``strftime`` pattern for Persian Jalali display.
@@ -84,10 +154,11 @@ def jalali_strftime_format(fmt: str) -> str:
     Named-month formats such as ``%b %d %Y`` become ``%d %B %Y`` so the
     result is ``23 مرداد 1405`` instead of ``Mor 23 1405``.
     Datetime patterns with time before date are reordered to date-first.
+    12-hour ``%I`` / ``%p`` becomes 24-hour (no بعد از ظهر / قبل از ظهر).
     """
     if not fmt:
         return fmt
-    out = fmt.replace("%b", "%B").replace("%a", "%A")
+    out = to_24h_strftime(fmt.replace("%b", "%B").replace("%a", "%A"))
     out = re.sub(r"%B(\s*),?\s*%d", r"%d\1%B", out)
     out = re.sub(r"%d\s*,\s*%B", "%d %B", out)
     out = re.sub(r"%B\s*,\s*%Y", "%B %Y", out)
@@ -124,17 +195,121 @@ def format_gregorian_as_jalali(value: date | datetime | time, fmt: str) -> str:
         jalali_value = jdatetime.datetime.fromgregorian(
             datetime=value, locale=jdatetime.FA_LOCALE
         )
-        formatted = jalali_value.strftime(jalali_fmt)
+        formatted = to_persian_datetime_digits(
+            strip_ampm_suffix(jalali_value.strftime(jalali_fmt))
+        )
         return preserve_rtl_datetime_order(formatted)
     jalali_value = jdatetime.date.fromgregorian(date=value, locale=jdatetime.FA_LOCALE)
-    return jalali_value.strftime(jalali_fmt)
+    return to_persian_digits(jalali_value.strftime(jalali_fmt))
+
+
+_BIDI_MARKS = re.compile(r"[\u200e\u200f\u202a-\u202e\u2066-\u2069]")
+_LOCALIZED_GREGORIAN = re.compile(
+    r"(?P<day>\d{1,2})\s+(?P<month>\S+)\s+(?P<year>\d{4})"
+    r"(?:[،,]?\s*(?:ساعت\s*)?(?P<hour>\d{1,2}):(?P<minute>\d{2})"
+    r"(?::(?P<second>\d{2}))?)?",
+    re.UNICODE,
+)
+
+# Django fa locale uses «اوت» for August; keep extra spellings too.
+_GREGORIAN_MONTHS = {
+    "january": 1,
+    "jan": 1,
+    "ژانویه": 1,
+    "february": 2,
+    "feb": 2,
+    "فوریه": 2,
+    "march": 3,
+    "mar": 3,
+    "مارس": 3,
+    "april": 4,
+    "apr": 4,
+    "آوریل": 4,
+    "may": 5,
+    "مه": 5,
+    "می": 5,
+    "june": 6,
+    "jun": 6,
+    "ژوئن": 6,
+    "july": 7,
+    "jul": 7,
+    "ژوئیه": 7,
+    "جولای": 7,
+    "august": 8,
+    "aug": 8,
+    "اوت": 8,
+    "آگوست": 8,
+    "اگست": 8,
+    "september": 9,
+    "sep": 9,
+    "sept": 9,
+    "سپتامبر": 9,
+    "october": 10,
+    "oct": 10,
+    "اکتبر": 10,
+    "november": 11,
+    "nov": 11,
+    "نوامبر": 11,
+    "december": 12,
+    "dec": 12,
+    "دسامبر": 12,
+}
+
+
+def _gregorian_month_number(token: str) -> int | None:
+    key = (token or "").strip().strip("،,").lower()
+    if key in _GREGORIAN_MONTHS:
+        return _GREGORIAN_MONTHS[key]
+    try:
+        from django.utils import dates
+
+        for mapping in (dates.MONTHS, dates.MONTHS_3, dates.MONTHS_ALT):
+            for number, name in mapping.items():
+                if str(name).strip().lower() == key:
+                    return int(number)
+    except Exception:
+        pass
+    return None
+
+
+def parse_localized_gregorian_display(value: str) -> date | datetime | None:
+    """
+    Parse Django-localized Gregorian strings such as
+    ``19 اوت 2026، ساعت 8:27`` (fa DATETIME_FORMAT ``j F Y، ساعت G:i``).
+    """
+    if not value or not str(value).strip():
+        return None
+    raw = _BIDI_MARKS.sub("", to_ascii_digits(str(value))).strip()
+    match = _LOCALIZED_GREGORIAN.search(raw)
+    if not match:
+        return None
+    year = int(match.group("year"))
+    if _is_plausible_jalali_year(year) or year < 1700:
+        return None
+    month = _gregorian_month_number(match.group("month"))
+    if not month:
+        return None
+    day = int(match.group("day"))
+    try:
+        if match.group("hour") is None:
+            return date(year, month, day)
+        return datetime(
+            year,
+            month,
+            day,
+            int(match.group("hour")),
+            int(match.group("minute")),
+            int(match.group("second") or 0),
+        )
+    except ValueError:
+        return None
 
 
 def parse_jalali_date(value: str) -> date | None:
     """Parse a Jalali date string into a Gregorian ``date``."""
     if not value or not str(value).strip():
         return None
-    raw = str(value).strip()
+    raw = to_ascii_digits(str(value).strip())
     for fmt in JALALI_DATE_FORMATS:
         try:
             jalali_value = jdatetime.datetime.strptime(raw, fmt)
@@ -149,7 +324,7 @@ def parse_jalali_datetime(value: str) -> datetime | None:
     """Parse a Jalali datetime string into a Gregorian ``datetime``."""
     if not value or not str(value).strip():
         return None
-    raw = str(value).strip()
+    raw = to_ascii_digits(str(value).strip())
     candidates = (raw, raw.replace("T", " "))
     for candidate in candidates:
         for fmt in JALALI_DATETIME_FORMATS:

--- a/horilla_jalali/locale/fa/LC_MESSAGES/django.po
+++ b/horilla_jalali/locale/fa/LC_MESSAGES/django.po
@@ -51,3 +51,63 @@ msgstr ""
 
 msgid "Calendar System"
 msgstr "سیستم تقویم"
+
+msgid "by"
+msgstr "توسط"
+
+#, python-format
+msgid "New %(model)s created"
+msgstr "%(model)s جدید ایجاد شد"
+
+#, python-format
+msgid "%(counter)s event"
+msgid_plural "%(counter)s events"
+msgstr[0] "%(counter)s رویداد"
+msgstr[1] "%(counter)s رویداد"
+
+msgid "Created"
+msgstr "ایجاد شد"
+
+msgid "edit"
+msgstr "ویرایش"
+
+msgid "edits"
+msgstr "ویرایش"
+
+msgid "event"
+msgstr "رویداد"
+
+msgid "events"
+msgstr "رویداد"
+
+#, python-format
+msgid "%(type)s added"
+msgstr "%(type)s اضافه شد"
+
+msgid "Added"
+msgstr "افزوده شد"
+
+msgid "Removed"
+msgstr "حذف شد"
+
+msgid "User"
+msgstr "کاربر"
+
+msgid "Url"
+msgstr "نشانی"
+
+msgid "URL"
+msgstr "نشانی"
+
+msgid "Sender"
+msgstr "فرستنده"
+
+msgid "Message"
+msgstr "پیام"
+
+msgid "Expand"
+msgstr "بزرگ‌نمایی"
+
+msgid "Collapse"
+msgstr "کوچک‌نمایی"
+

--- a/horilla_jalali/static/horilla_jalali/js/horilla_jalali.js
+++ b/horilla_jalali/static/horilla_jalali/js/horilla_jalali.js
@@ -57,6 +57,16 @@
         return String(value).padStart(2, "0");
     }
 
+    function toAsciiDigits(value) {
+        return String(value || "")
+            .replace(/[۰-۹]/g, function (ch) {
+                return String(ch.charCodeAt(0) - 0x06f0);
+            })
+            .replace(/[٠-٩]/g, function (ch) {
+                return String(ch.charCodeAt(0) - 0x0660);
+            });
+    }
+
     function getLabels() {
         var lang = (document.documentElement.lang || "en").split("-")[0].toLowerCase();
         return LABELS[lang] || LABELS.en;
@@ -166,7 +176,7 @@
         if (!jalaliValue) {
             return "";
         }
-        var datePart = jalaliValue.trim().split(" ")[0];
+        var datePart = toAsciiDigits(jalaliValue).trim().split(" ")[0];
         var chunks = datePart.split("/");
         if (chunks.length !== 3) {
             return "";
@@ -415,7 +425,7 @@
             autoShow: true,
             autoHide: true,
             hideAfterChange: true,
-            persianDigits: false,
+            persianDigits: true,
             time: false,
             zIndex: 10050,
         });

--- a/static/assets/css/history-rtl.css
+++ b/static/assets/css/history-rtl.css
@@ -1,0 +1,79 @@
+/**
+ * History tab RTL / BiDi fixes (detail History across Leads, Opportunities, …).
+ *
+ * Kept in this file on purpose so it does not conflict with rtl.css changes
+ * on other branches (e.g. web-to-lead). Loaded after rtl.css from the
+ * project overlay of inject_html/rtl_assets.html.
+ */
+
+/* Date group stays at the reading start (right); event count is secondary. */
+[dir="rtl"] #history-main .history-day > summary {
+  text-align: start;
+}
+
+/* Accordion chevron fallback when the core template's fa-chevron-right is used. */
+[dir="rtl"] #history-main .history-day summary .fa-chevron-right {
+  transform: scaleX(-1);
+}
+
+[dir="rtl"] #history-main .history-day[open] summary .fa-chevron-right {
+  transform: scaleX(-1) rotate(-90deg) !important;
+}
+
+/* Timestamps stay on the reading-start side (right in RTL), matching core. */
+#history-main .history-entry-time {
+  direction: ltr;
+  unicode-bidi: isolate;
+}
+
+[dir="rtl"] #history-main .history-entry-time {
+  text-align: start;
+}
+
+[dir="rtl"] #history-main .history-entry-body {
+  text-align: start;
+}
+
+#history-main .history-day-count {
+  unicode-bidi: isolate;
+}
+
+/* Isolate each field/value so mixed Persian + URL/English does not reorder. */
+#history-main .history-kv {
+  unicode-bidi: isolate;
+  display: inline-block;
+  max-width: 100%;
+  vertical-align: baseline;
+}
+
+#history-main .history-kv-value {
+  unicode-bidi: isolate;
+  word-break: break-word;
+}
+
+#history-main .history-actor {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.125rem;
+  unicode-bidi: isolate;
+  white-space: nowrap;
+  vertical-align: middle;
+}
+
+/* Core template uses physical ml-0.5 on the actor chip; rtl.css does not flip it. */
+[dir="rtl"] #history-main .ml-0\.5 {
+  margin-left: 0;
+  margin-right: 0.125rem;
+}
+
+[dir="rtl"] #history-main .history-filter-bar {
+  justify-content: flex-start;
+}
+
+.history-filter-actions {
+  text-align: right;
+}
+
+[dir="rtl"] .history-filter-actions {
+  text-align: right;
+}

--- a/static/assets/css/history-tab.css
+++ b/static/assets/css/history-tab.css
@@ -1,0 +1,24 @@
+/**
+ * History tab layout (expand + toolbar). Not RTL-specific.
+ * Loaded from the project overlay of history_tab.html.
+ */
+
+#history-main {
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+}
+
+#history-main .history-toolbar {
+  position: static;
+}
+
+#history-container {
+  min-height: 0;
+}
+
+/* Grow the tab pane by hiding the detail header/pipeline for this page. */
+#detailViewport.history-tab-expanded #detailHeaderCard,
+#detailViewport.history-tab-expanded #pipeline-choices {
+  display: none !important;
+}

--- a/templates/history_tab.html
+++ b/templates/history_tab.html
@@ -1,0 +1,243 @@
+{# Project overlay of generics/history_tab.html for RTL/Farsi. Core file is unchanged. #}
+{% load history_i18n %}
+{% trans "Expand" as history_expand_label %}
+{% trans "Collapse" as history_collapse_label %}
+<link rel="stylesheet" href="{% static 'assets/css/history-tab.css' %}">
+<div
+    class="custom-scroll overflow-hidden overflow-y-auto h-full"
+    role="tabpanel"
+    aria-labelledby="history-tab"
+    id="history-main"
+>
+    <div class="w-full mx-auto relative">
+        <div class="history-toolbar history-filter-bar bg-white mx-auto flex justify-end gap-3 pb-2">
+            {% if filter_applied %}
+                <button
+                    onclick="$('#tab-history').click()"
+                    class="text-sm border-[1px] hover:bg-primary-700 hover:bg-primary-600 rounded-[5px] px-4 py-2 text-primary-600 flex gap-3 btn-with-icon transition duration-300 hover:text-white"
+                >
+                    {% trans "Clear Filters" %}
+                </button>
+            {% endif %}
+            <button
+                type="button"
+                id="history-expand-btn"
+                class="flex items-center gap-3 text-sm p-2 rounded-md bg-primary-600 text-white shadow"
+                title="{% trans 'Expand' %}"
+                aria-label="{% trans 'Expand' %}"
+                aria-pressed="false"
+                onclick="window.toggleHistoryTabSize && window.toggleHistoryTabSize(this)"
+            >
+                <i class="fa-solid fa-expand" aria-hidden="true"></i>
+            </button>
+            <button
+                id="filter-button"
+                hx-get="{{request.path}}?show_filter=true"
+                hx-target="#filtermodalBox"
+                hx-swap="innerHTML"
+                hx-trigger="click"
+                hx-on:click="openFilterModal()"
+                hx-on::after-swap="if (window.initHorillaJalaliInputs) window.initHorillaJalaliInputs(document.getElementById('filtermodalBox'))"
+                class="flex items-center gap-3 text-sm p-2 rounded-md bg-primary-600 text-white shadow"
+            >
+                <img src="{% static 'assets/icons/filter1.svg' %}" alt="{% trans 'Filter' %}" width="18">
+            </button>
+        </div>
+
+        <div id="history-container" class="mt-4">
+            {% if page_obj %}
+                {% for date, entries in page_obj %}
+                    {% with entries=entries|collapse_redundant_history %}
+                        <details
+                            class="history-day border border-[#e9e9e9] rounded-[8px] mb-3 overflow-hidden group"
+                            {% if forloop.first %}
+                                open
+                            {% endif %}
+                        >
+                            <summary class="list-none flex items-center justify-between gap-3 px-4 py-3 cursor-pointer bg-white [&::-webkit-details-marker]:hidden">
+                                <div class="flex items-center gap-3 min-w-0">
+                                    <i
+                                        class="history-day-chevron fa-solid {% if LANGUAGE_BIDI %}fa-chevron-left group-open:-rotate-90{% else %}fa-chevron-right group-open:rotate-90{% endif %} text-[10px] text-gray-400 transition-transform duration-150"
+                                    ></i>
+                                    <span
+                                        class="text-sm font-semibold text-black whitespace-nowrap"
+                                        dir="ltr"
+                                    >{{ date|history_datetime }}</span>
+                                    <div class="hidden sm:flex items-center gap-1.5 flex-wrap">
+                                        {% for tag in entries|history_day_tags %}
+                                            <span
+                                                class="text-[10px] font-bold px-2 py-0.5 rounded-full {% if tag.is_edit %}bg-primary-300 text-primary-700{% else %}bg-gray-100 text-gray-600{% endif %}"
+                                            >
+                                                {{ tag.label }}
+                                            </span>
+                                        {% endfor %}
+                                    </div>
+                                </div>
+                                <span class="history-day-count text-xs text-gray-500 whitespace-nowrap">
+                                    {% blocktrans count counter=entries|length %}{{ counter }} event{% plural %}{{ counter }} events{% endblocktrans %}
+                                </span>
+                            </summary>
+
+                            <div class="px-4 pb-3 pt-1 border-t border-[#e9e9e9]">
+                                {% for entry in entries %}
+                                    <div class="history-entry flex items-start gap-3 py-2 {% if not forloop.last %}border-b border-[#f5f5f5]{% endif %}">
+                                        <span
+                                            class="history-entry-time text-xs text-gray-500 whitespace-nowrap flex-shrink-0 pt-px w-[170px]"
+                                            dir="ltr"
+                                        >{{ entry.timestamp|history_datetime }}</span>
+
+                                        <div class="history-entry-body min-w-0 flex-1">
+                                            <p class="text-xs text-gray-700 text-start">
+                                                {% if entry|is_create_entry %}
+                                                    {% with type_label=entry|create_type_display status_label=entry|create_status_display:model_name extra_changes=entry|create_extra_changes:model_name %}
+                                                        {% if type_label %}
+                                                            <span
+                                                                class="inline-flex items-center gap-1 bg-primary-100 text-primary-700 font-semibold px-2 py-0.5 rounded-full me-1"
+                                                            >{{ type_label }}</span>
+                                                            {% if status_label %}<span class="mx-1">·</span><span
+                                                                    class="history-kv"
+                                                                ><span class="font-bold text-black">{% trans "Status" %}:</span>
+                                                                    <span class="history-kv-value" dir="auto">{{ status_label }}</span></span>{% endif %}
+                                                        {% else %}
+                                                            <span
+                                                                class="inline-flex items-center gap-1 bg-primary-100 text-primary-700 font-semibold px-2 py-0.5 rounded-full me-1"
+                                                            >{% blocktrans trimmed with model=entry.content_type|content_type_verbose_name|capfirst %}New {{ model }} created{% endblocktrans %}</span>
+                                                        {% endif %}
+                                                        {% for field, values in extra_changes.items %}
+                                                            <span class="mx-1">·</span>
+                                                            <span class="history-kv">
+                                                                <span class="font-bold text-black">{% trans field %}:</span>
+                                                                {% if values.0 == "__m2m__" %}
+                                                                    <span
+                                                                        class="history-diff-chip {% if values.1 == 'delete' %}history-diff-chip-removed{% else %}history-diff-chip-added{% endif %}"
+                                                                    >{{ values.3|default:values.2 }}</span>
+                                                                {% elif entry|history_is_date_field:field %}
+                                                                    <span class="history-kv-value" dir="ltr">{{ values.1|html_to_text|default:"--"|history_datetime|truncate_diff_value }}</span>
+                                                                {% else %}
+                                                                    <span class="history-kv-value" dir="auto">{{ values.1|html_to_text|default:"--"|truncate_diff_value }}</span>
+                                                                {% endif %}
+                                                            </span>
+                                                        {% endfor %}
+                                                        {% for field, value in entry.creation_time_additions %}
+                                                            <span class="mx-1">·</span>
+                                                            <span class="history-kv">
+                                                                <span class="font-bold text-black">{% trans field %}:</span>
+                                                                <span
+                                                                    class="history-diff-chip {% if value.1 == 'delete' %}history-diff-chip-removed{% else %}history-diff-chip-added{% endif %}"
+                                                                >{{ value.3|default:value.2 }}</span>
+                                                            </span>
+                                                        {% endfor %}
+                                                        {% include "partials/history_entry_actor.html" with actor=entry.actor %}
+                                                    {% endwith %}
+                                                {% else %}
+                                                    {% with display_changes=entry|history_changes_display subject=entry|related_entry_subject:model_name %}
+                                                        {% if display_changes %}
+                                                            {% if subject %}<span
+                                                                    class="inline-flex items-center gap-1 bg-primary-100 text-primary-700 font-semibold px-2 py-0.5 rounded-full me-1"
+                                                                    dir="auto"
+                                                                >{{ subject }}</span>{% endif %}
+                                                            {% for field, values in display_changes.items %}
+                                                                <span class="history-kv">
+                                                                    <span class="font-bold text-black">{% trans field %}:</span>
+                                                                    {% if values.0 == "__m2m__" %}
+                                                                        <span
+                                                                            class="history-diff-chip {% if values.1 == 'delete' %}history-diff-chip-removed{% else %}history-diff-chip-added{% endif %}"
+                                                                        >{{ values.3|default:values.2 }}</span>
+                                                                    {% elif entry|history_is_date_field:field %}
+                                                                        <span class="history-kv-value" dir="ltr">{{ values.0|html_to_text|default:"--"|history_datetime|truncate_diff_value }}</span>
+                                                                        → <span
+                                                                            class="history-diff-chip"
+                                                                        >{{ values.1|html_to_text|default:"--"|history_datetime|truncate_diff_value }}</span>
+                                                                    {% else %}
+                                                                        <span class="history-kv-value" dir="auto">{{ values.0|html_to_text|default:"--"|truncate_diff_value }}</span>
+                                                                        → <span
+                                                                            class="history-diff-chip"
+                                                                        >{{ values.1|html_to_text|default:"--"|truncate_diff_value }}</span>
+                                                                    {% endif %}
+                                                                </span>
+                                                                {% if not forloop.last %}<br>{% endif %}
+                                                            {% endfor %}
+                                                            {% include "partials/history_entry_actor.html" with actor=entry.actor %}
+                                                        {% else %}
+                                                            <span
+                                                                class="inline-flex items-center gap-1 bg-primary-100 text-primary-700 font-semibold px-2 py-0.5 rounded-full me-1"
+                                                                dir="auto"
+                                                            >{% if subject %}{{ subject }}{% else %}{{ entry.content_type|content_type_verbose_name|capfirst }}{% endif %}</span>
+                                                            {% trans "updated" %}
+                                                            {% include "partials/history_entry_actor.html" with actor=entry.actor %}
+                                                        {% endif %}
+                                                    {% endwith %}
+                                                {% endif %}
+                                            </p>
+                                        </div>
+                                    </div>
+                                {% endfor %}
+                            </div>
+                        </details>
+                    {% endwith %}
+                {% endfor %}
+                {% if page_obj.has_next %}
+                    <div
+                        id="load-more-trigger"
+                        hx-get="{{request.path}}?{{request.GET.urlencode }}&page={{ page_obj.next_page_number }}"
+                        hx-trigger="revealed"
+                        hx-swap="innerHTML"
+                        hx-target="#history-main"
+                        class="h-1"
+                    >
+                    </div>
+                {% endif %}
+            {% else %}
+                {% trans "No history available for this object." as empty_state_message %}
+                {% include "components/empty_state.html" with message=empty_state_message %}
+            {% endif %}
+        </div>
+    </div>
+    <script>
+        (function () {
+            var EXPAND_LABEL = "{{ history_expand_label|escapejs }}";
+            var COLLAPSE_LABEL = "{{ history_collapse_label|escapejs }}";
+
+            window.toggleHistoryTabSize = function (btn) {
+                var viewport = document.getElementById("detailViewport");
+                if (!viewport || !btn) {
+                    return;
+                }
+                var expanded = viewport.classList.toggle("history-tab-expanded");
+                window.syncHistoryExpandBtn(btn, expanded);
+                if (typeof window.scheduleViewportFit === "function") {
+                    window.scheduleViewportFit();
+                }
+            };
+
+            window.syncHistoryExpandBtn = function (btn, expanded) {
+                var button = btn || document.getElementById("history-expand-btn");
+                var viewport = document.getElementById("detailViewport");
+                if (!button) {
+                    return;
+                }
+                if (typeof expanded !== "boolean") {
+                    expanded = !!(viewport && viewport.classList.contains("history-tab-expanded"));
+                }
+                var label = expanded ? COLLAPSE_LABEL : EXPAND_LABEL;
+                button.setAttribute("aria-pressed", expanded ? "true" : "false");
+                button.setAttribute("title", label);
+                button.setAttribute("aria-label", label);
+                var icon = button.querySelector("i");
+                if (icon) {
+                    icon.className = expanded
+                        ? "fa-solid fa-compress"
+                        : "fa-solid fa-expand";
+                }
+            };
+
+            if (!window._historyTabExpandBound) {
+                window._historyTabExpandBound = true;
+                document.body.addEventListener("htmx:afterSettle", function () {
+                    window.syncHistoryExpandBtn();
+                });
+            }
+            window.syncHistoryExpandBtn();
+        })();
+    </script>
+</div>

--- a/templates/inject_html/rtl_assets.html
+++ b/templates/inject_html/rtl_assets.html
@@ -1,0 +1,11 @@
+{% if LANGUAGE_BIDI %}
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link
+        rel="stylesheet"
+        href="https://fonts.googleapis.com/css2?family=Vazirmatn:wght@100..900&display=swap"
+    >
+    <link rel="stylesheet" href="{% static 'assets/css/rtl.css' %}">
+    {# Extra history-tab RTL file — do not fold into rtl.css (avoids PR conflicts). #}
+    <link rel="stylesheet" href="{% static 'assets/css/history-rtl.css' %}">
+{% endif %}

--- a/templates/partials/history_entry_actor.html
+++ b/templates/partials/history_entry_actor.html
@@ -1,0 +1,8 @@
+{% if actor %}
+    <span class="history-actor">
+        {% trans "by" %}
+        <span
+            class="inline-flex items-center gap-1 bg-gray-100 text-gray-800 font-semibold px-2 py-0.5 rounded-full ms-0.5"
+        >{{ actor }}</span>
+    </span>
+{% endif %}

--- a/templates/partials/history_filter_form.html
+++ b/templates/partials/history_filter_form.html
@@ -1,0 +1,36 @@
+<div class="p-5">
+    <div class="flex justify-between items-center mb-4">
+        <h2 class="text-md font-semibold">{% trans "Filter" %}</h2>
+        <button onclick="closeFilterModal()" class="text-gray-500 hover:text-gray-500 text-xl cursor-pointer">
+            <img src="{% static 'assets/icons/close.svg' %}" alt="{% trans 'Close' %}">
+        </button>
+    </div>
+    <form
+        hx-get="{{ request.path }}"
+        hx-target="#history-main"
+        hx-swap="innerHTML"
+        hx-trigger="submit"
+        hx-select="#history-main"
+        class="space-y-4"
+        hx-on::after-request="closeFilterModal()"
+    >
+        <label for="{{ form.filter_date.id_for_label }}" class="block text-sm font-medium text-gray-700">
+            {% trans "Select date to filter" %}
+        </label>
+        {{ form.filter_date }}
+
+        <div class="history-filter-actions pt-2">
+            <button type="submit" class="bg-primary-600 text-white text-sm px-4 py-2 rounded shadow">
+                {% trans "Apply" %}
+            </button>
+        </div>
+    </form>
+    <script>
+        (function () {
+            var box = document.getElementById("filtermodalBox");
+            if (window.initHorillaJalaliInputs && box) {
+                window.initHorillaJalaliInputs(box);
+            }
+        })();
+    </script>
+</div>


### PR DESCRIPTION
## Summary

The History tab (Leads, Opportunities, and other CRM detail pages) was hard to use in Persian/RTL: dates were Gregorian, field diffs showed month names like «اوت», the filter modal was English with a Gregorian picker, and a long audit trail was squeezed into a short pane under the record header.

This change overlays the History templates and CSS in the project (Horilla core and `rtl.css` are untouched) so Farsi users get Shamsi dates, a usable filter, and enough room to scroll.

## Why the expand (full screen) button

On a busy record the History list is long, but the tab only gets the leftover height under the detail header and pipeline. Users had to scroll inside a small box, which is tiring when there are many logs.

The new expand control hides the detail header and pipeline for that page (`#detailHeaderCard`, `#pipeline-choices`) so History uses the full viewport. Collapse restores the normal layout.

The core filter bar was also `sticky`, so it stayed on top of the list and stole even more of that already-small scroll area. The overlay toolbar is static so the list can scroll cleanly.

## Filter bug

- The sticky filter button overlapped the timeline and reduced scroll space.
- The filter modal used the auto-generated English label **Filter date**, not a translated string.
- The field was a native Gregorian `type="date"` picker, so Farsi users could not pick a Shamsi day.
- After HTMX loaded the modal, the Jalali picker often did not attach.

The overlay modal uses **Select date to filter** / **Apply**, initializes `initHorillaJalaliInputs` after swap, and uses Persian digits in the Shamsi picker. Enable `horilla_jalali` in `local_settings.py` (`INSTALLED_APPS += ["horilla_jalali"]`).

## What else changed

- **Shamsi timestamps** on day groups and each row (`۱۴۰۵-۰۵-۲۸ ۱۵:۵۲`, 24-hour, no seconds, Persian digits).
- **Field diffs** such as start/end/updated-at: Django’s Gregorian «19 اوت 2026، ساعت 8:27» is parsed and shown as Shamsi instead.
- **RTL / i18n**: chevron direction, BiDi isolation, «توسط», «… جدید ایجاد شد», event counts, field labels.
- **Dockerfile**: `gettext` so `compilemessages` works in the image.

## Test plan

- [ ] Open a lead History tab in Farsi; timestamps and date fields are Shamsi, not «اوت».
- [ ] With many history rows, expand: header/pipeline hide and the list is easier to scroll; collapse restores them.
- [ ] Filter bar does not stick over the list.
- [ ] Filter modal is translated and opens a Shamsi date picker; apply filters by day.
- [ ] English / LTR History still looks and behaves as before.